### PR TITLE
Add an API module with a request cache

### DIFF
--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,0 +1,27 @@
+const fetch = require('node-fetch');
+
+const HOST = 'https://www.penguinwatch.org';
+const PROJECT = 'illustratedlife';
+const CACHING = true;
+
+const apiCache = {};
+
+async function get(url) {
+  console.log(`Request: ${url}`);
+  if (CACHING && apiCache[url]) {
+    console.log('using cache')
+    return apiCache[url];
+  }
+
+  const response = await fetch(
+      `${HOST}/_ouroboros_api/projects/${PROJECT}/talk/${url}`,
+    {
+      headers: { Accept: "application/json" }
+    }
+  );
+  const data = await response.json();
+  apiCache[url] = Object.assign({}, data);
+  return data;
+}
+
+module.exports = { get };

--- a/src/helpers/fetchBoard.js
+++ b/src/helpers/fetchBoard.js
@@ -1,34 +1,25 @@
-const fetch = require('node-fetch');
+const API = require('./api')
 const fetchDiscussion = require('./fetchDiscussion');
 
-async function fetchPage(host, project, boardID, page) {
-  console.log('fetching board page', boardID, page)
-  const response = await fetch(
-      `${host}/_ouroboros_api/projects/${project}/talk/boards/${boardID}?page=${page}`,
-    {
-      headers: { Accept: "application/json" }
-    }
-  );
-  const data = await response.json();
+async function fetchPage(boardID, page) {
+  const data = await API.get(`boards/${boardID}?page=${page}`);
   return data;
 }
 
-module.exports = async function fetchBoard(host, project, board, pages) {
-  let discussions = [];
+module.exports = async function fetchBoard(board, pages) {
+  const discussions = [];
   console.log('build discussions', board.zooniverse_id, board.discussions, pages)
 
   for (let page = 1; page <= pages; page++) {
-    const pageData = await fetchPage(host, project, board.zooniverse_id, page);
-    discussions = discussions.concat(pageData.discussions);
+    const pageData = await fetchPage(board.zooniverse_id, page);
+
+    for (discussion of pageData.discussions) {
+      const pages = Math.ceil(discussion.comments_count / 10) || 1;
+      const fullDiscussion = await fetchDiscussion(board, discussion, pages);
+      discussions.push(fullDiscussion);
+    }
   }
 
-  for (discussion of discussions) {
-    const pages = Math.ceil(discussion.comments_count / 10) || 1;
-    const fullDiscussion = await fetchDiscussion(host, project, board, discussion, pages);
-    discussion = fullDiscussion;
-  }
-
-  board.discussions = discussions;
-  return board;
+  return Object.assign({}, board, { discussions });
 }
 

--- a/src/helpers/fetchBoard.js
+++ b/src/helpers/fetchBoard.js
@@ -14,7 +14,8 @@ module.exports = async function fetchBoard(board, pages) {
     const pageData = await fetchPage(board.zooniverse_id, page);
 
     for (discussion of pageData.discussions) {
-      const pages = Math.ceil(discussion.comments_count / 10) || 1;
+      const commentsCount = discussion.comments_count || discussion.comments;
+      const pages = Math.ceil(commentsCount / 10) || 1;
       const fullDiscussion = await fetchDiscussion(board, discussion, pages);
       discussions.push(fullDiscussion);
     }

--- a/src/helpers/fetchBoards.js
+++ b/src/helpers/fetchBoards.js
@@ -1,8 +1,5 @@
-const fetch = require('node-fetch');
+const API = require('./api');
 const fetchBoard = require('./fetchBoard');
-
-const HOST = 'https://www.penguinwatch.org'
-const PROJECT = 'illustratedlife'
 
 const CATEGORIES = [
   'chat',
@@ -12,7 +9,7 @@ const CATEGORIES = [
 async function discussionBoard(board) {
   if ( board.zooniverse_id && board.discussions ) {
     const pages = Math.ceil(board.discussions / 10) || 1
-    const fullBoard = await fetchBoard(HOST, PROJECT, board, pages);
+    const fullBoard = await fetchBoard(board, pages);
     console.log('board discussions', board.zooniverse_id, board.discussions.length)
     return fullBoard
   }
@@ -20,13 +17,7 @@ async function discussionBoard(board) {
 }
 
 module.exports = async function fetchBoards() {
-  const response = await fetch(
-      `${HOST}/_ouroboros_api/projects/${PROJECT}/talk/boards`,
-    {
-      headers: { Accept: "application/json" }
-    }
-  );
-  const boards = await response.json();
+  const boards = await API.get('boards/');
   for (category of CATEGORIES) {
     console.log(category)
     const categoryBoards = await Promise.all(boards[category].map(discussionBoard));

--- a/src/helpers/fetchBoards.js
+++ b/src/helpers/fetchBoards.js
@@ -8,9 +8,10 @@ const CATEGORIES = [
 ]
 async function discussionBoard(board) {
   if ( board.zooniverse_id && board.discussions ) {
-    const pages = Math.ceil(board.discussions / 10) || 1
+    const discussionsCount = board.discussions_count || board.discussions;
+    const pages = Math.ceil(discussionsCount / 10) || 1
     const fullBoard = await fetchBoard(board, pages);
-    console.log('board discussions', board.zooniverse_id, board.discussions.length)
+    console.log('board discussions', board.zooniverse_id, discussionsCount)
     return fullBoard
   }
   return board;

--- a/src/helpers/fetchDiscussion.js
+++ b/src/helpers/fetchDiscussion.js
@@ -1,27 +1,19 @@
-const fetch = require('node-fetch');
+const API = require('./api');
 
-async function fetchPage(host, project, boardID, discussionID, page) {
-  console.log('fetching discussion page', boardID, page)
-  const response = await fetch(
-      `${host}/_ouroboros_api/projects/${project}/talk/boards/${boardID}/discussions/${discussionID}?page=${page}`,
-    {
-      headers: { Accept: "application/json" }
-    }
-  );
-  const data = await response.json();
+async function fetchPage(boardID, discussionID, page) {
+  const data = await API.get(`boards/${boardID}/discussions/${discussionID}?page=${page}`);
   return data;
 }
 
-module.exports = async function fetchDiscussion(host, project, board, discussion, pages) {
+module.exports = async function fetchDiscussion(board, discussion, pages) {
   let comments = [];
   console.log('build comments', discussion.zooniverse_id, discussion.comments, pages)
 
   for (let page = 1; page <= pages; page++) {
-    const pageData = await fetchPage(host, project, discussion.board._id, discussion.zooniverse_id, page);
+    const pageData = await fetchPage(discussion.board._id, discussion.zooniverse_id, page);
     comments = comments.concat(pageData.comments);
   }
 
-  discussion.comments = comments;
-  return discussion;
+  return Object.assign({}, discussion, { comments });
 }
 


### PR DESCRIPTION
Add an API module for common request code, include a cache that stores response data by request URL. Clean up some hacky code that was modifying objects by reference, which then indirectly modifies the cache. Clean up calculation of discussion counts and comment counts.