### PR TITLE
Add a data store

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -9,12 +9,16 @@ a {
   @apply underline;
 }
 
+li {
+  @apply ml-8;
+}
+
 p {
   @apply mb-2;
 }
 
 .container {
-  @apply max-w-xl mx-auto;
+  @apply max-w-3xl mx-auto;
 }
 
 .comment {

--- a/src/helpers/fetchBoard.js
+++ b/src/helpers/fetchBoard.js
@@ -1,5 +1,6 @@
 const API = require('./api')
 const fetchDiscussion = require('./fetchDiscussion');
+const store = require('./store');
 
 async function fetchPage(boardID, page) {
   const data = await API.get(`boards/${boardID}?page=${page}`);
@@ -8,8 +9,9 @@ async function fetchPage(boardID, page) {
 
 module.exports = async function fetchBoard(board, pages) {
   const discussions = [];
-  console.log('build discussions', board.zooniverse_id, board.discussions, pages)
+  console.log('build discussions', board.zooniverse_id, board.discussions, pages);
 
+  let fullBoard = {};
   for (let page = 1; page <= pages; page++) {
     const pageData = await fetchPage(board.zooniverse_id, page);
 
@@ -17,10 +19,13 @@ module.exports = async function fetchBoard(board, pages) {
       const commentsCount = discussion.comments_count || discussion.comments;
       const pages = Math.ceil(commentsCount / 10) || 1;
       const fullDiscussion = await fetchDiscussion(board, discussion, pages);
+      store.discussions[fullDiscussion.zooniverse_id] = fullDiscussion;
       discussions.push(fullDiscussion);
     }
+
+    fullBoard = pageData;
   }
 
-  return Object.assign({}, board, { discussions });
+  return Object.assign({}, fullBoard, { discussions });
 }
 

--- a/src/helpers/fetchBoards.js
+++ b/src/helpers/fetchBoards.js
@@ -1,5 +1,6 @@
 const API = require('./api');
 const fetchBoard = require('./fetchBoard');
+const store = require('./store');
 
 const CATEGORIES = [
   'chat',
@@ -8,11 +9,13 @@ const CATEGORIES = [
 ]
 async function discussionBoard(board) {
   if ( board.zooniverse_id && board.discussions ) {
+    const { boards } = store;
     const discussionsCount = board.discussions_count || board.discussions;
     const pages = Math.ceil(discussionsCount / 10) || 1
     const fullBoard = await fetchBoard(board, pages);
-    console.log('board discussions', board.zooniverse_id, discussionsCount)
-    return fullBoard
+    console.log('board discussions', board.zooniverse_id, discussionsCount);
+    boards[fullBoard.category] = boards[fullBoard.category] || {};
+    boards[fullBoard.category][board.zooniverse_id] = fullBoard;
   }
   return board;
 }

--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -1,0 +1,4 @@
+module.exports = {
+  boards: {},
+  discussions: {}
+};

--- a/src/site/_data/boards.js
+++ b/src/site/_data/boards.js
@@ -1,7 +1,8 @@
 const fetchBoards = require('../../helpers/fetchBoards');
+const store = require('../../helpers/store');
 
 module.exports = async function () {
   console.log('building boards');
-  const boards = await fetchBoards();
-  return boards;
+  await fetchBoards();
+  return store.boards;
 }

--- a/src/site/_data/discussions.js
+++ b/src/site/_data/discussions.js
@@ -1,4 +1,6 @@
 const fetchBoards = require('../../helpers/fetchBoards');
+const store = require('../../helpers/store');
+
 const CATEGORIES = [
   'chat',
   'help',
@@ -15,14 +17,9 @@ function filterDiscussions(discussion) {
 
 module.exports = async function fetchDiscussions() {
   console.log('building discussions');
-  const boards = await fetchBoards();
-  let discussions = []
-  for ( category of CATEGORIES ) {
-    const boardDiscussions = boards[category].forEach( function (board) {
-      discussions = discussions.concat(board.discussions);
-    });
-  }
-  console.log('Built discussions', discussions.length)
-  console.log('DISCUSSIONS', discussions.map(logDiscussion))
-  return discussions.filter(filterDiscussions);
+  await fetchBoards();
+  const { discussions } = store;
+  console.log('Built discussions', Object.keys(discussions).length)
+  console.log('DISCUSSIONS', Object.values(discussions).map(logDiscussion))
+  return Object.values(discussions).filter(filterDiscussions);
 }

--- a/src/site/api/chat.njk
+++ b/src/site/api/chat.njk
@@ -1,6 +1,7 @@
 ---
 pagination:
   data: boards.chat
+  resolve: values
   size: 1
   alias: board
 permalink: "/api/boards/{{ board.zooniverse_id }}.json"

--- a/src/site/api/discussion.njk
+++ b/src/site/api/discussion.njk
@@ -1,6 +1,7 @@
 ---
 pagination:
   data: discussions
+  resolve: values
   size: 1
   alias: discussion
 permalink: "/api/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id}}.json"

--- a/src/site/api/help.njk
+++ b/src/site/api/help.njk
@@ -1,6 +1,7 @@
 ---
 pagination:
   data: boards.help
+  resolve: values
   size: 1
   alias: board
 permalink: "/api/boards/{{ board.zooniverse_id }}.json"

--- a/src/site/api/science.njk
+++ b/src/site/api/science.njk
@@ -1,6 +1,7 @@
 ---
 pagination:
   data: boards.science
+  resolve: values
   size: 1
   alias: board
 permalink: "/api/boards/{{ board.zooniverse_id }}.json"

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -14,6 +14,8 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
   {%- for discussion in board.discussions -%}
     <li>
       <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+      <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+      <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       <hr>
     </li>
   {%- endfor -%}

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -10,6 +10,7 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
 ---
 <h1>{{ board.title }}</h1>
 <p>{{ board.description }}</p>
+<p>{{ board.discussions.length }} conversations</p>
 
 <ul class="container">
   {%- for discussion in board.discussions -%}

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -3,6 +3,7 @@ title: Discussion board
 layout: default
 pagination:
   data: boards.chat
+  resolve: values
   size: 1
   alias: board
 permalink: "/boards/{{ board.zooniverse_id }}/"

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -3,6 +3,7 @@ title: Discussion board
 layout: default
 pagination:
   data: boards.help
+  resolve: values
   size: 1
   alias: board
 permalink: "/boards/{{ board.zooniverse_id }}/"

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -14,6 +14,8 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
   {%- for discussion in board.discussions -%}
     <li>
       <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+      <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+      <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       <hr>
     </li>
   {%- endfor -%}

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -10,6 +10,7 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
 ---
 <h1>{{ board.title }}</h1>
 <p>{{ board.description }}</p>
+<p>{{ board.discussions.length }} conversations</p>
 
 <ul class="container">
   {%- for discussion in board.discussions -%}

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -5,7 +5,7 @@ layout: default
 <ul>
   {%- for category, categoryBoards in boards -%}
   <li>
-    <h2>{{ category }}</h2>
+    <h2>{{ category | capitalize }}</h2>
     <hr>
     <ul>
       {%- for board in categoryBoards -%}

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -7,7 +7,7 @@ layout: default
   <li>
     <h2>{{ category | capitalize }}</h2>
     <hr>
-    <ul>
+    <ul class="container">
       {%- for board in categoryBoards -%}
         <li>
           <p><a href="./{{ board.zooniverse_id }}">{{ board.title }}</a></p>

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -8,9 +8,9 @@ layout: default
     <h2>{{ category | capitalize }}</h2>
     <hr>
     <ul class="container">
-      {%- for board in categoryBoards -%}
+      {%- for boardID, board in categoryBoards -%}
         <li>
-          <p><a href="./{{ board.zooniverse_id }}">{{ board.title }}</a></p>
+          <p><a href="./{{ boardID }}">{{ board.title }}</a></p>
           <p>{{ board.description }}</p>
           <hr>
         </li>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -14,6 +14,8 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
   {%- for discussion in board.discussions -%}
     <li>
       <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+      <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+      <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       <hr>
     </li>
   {%- endfor -%}

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -10,6 +10,7 @@ permalink: "/boards/{{ board.zooniverse_id }}/"
 ---
 <h1>{{ board.title }}</h1>
 <p>{{ board.description }}</p>
+<p>{{ board.discussions.length }} conversations</p>
 
 <ul class="container">
   {%- for discussion in board.discussions -%}

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -3,6 +3,7 @@ title: Discussion board
 layout: default
 pagination:
   data: boards.science
+  resolve: values
   size: 1
   alias: board
 permalink: "/boards/{{ board.zooniverse_id }}/"

--- a/src/site/discussions/discussion.md
+++ b/src/site/discussions/discussion.md
@@ -3,6 +3,7 @@ title: Discussion board
 layout: default
 pagination:
   data: discussions
+  resolve: values
   size: 1
   alias: discussion
 permalink: "/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id}}/"


### PR DESCRIPTION
Add a plain object as a data store. Store boards and discussions, keyed by ID, as we recurse the API. Update views to use data object values for pagination.

Add some styling and additional metadata to the discussion listings.