### PR TITLE
Add tagged collections of items

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -68,29 +68,27 @@ module.exports = function(eleventyConfig) {
     return { subjects, discussions, userCollections };
   }
 
-  function uniqueTags(data) {
-    const tags = {};
-    const { discussions, subjects, userCollections } = data;
-
-    for (subject of Object.values(subjects)) {
-      subject.tags && subject.tags.forEach(tag => {
-        tags[tag._id] = tag;
+  function uniqueTags(items, tags) {
+    for (item of items) {
+      item.tags && item.tags.forEach(tag => {
+        tagName = tag._id || tag;
+        tags[tagName] = tag;
       });
     }
+    return tags;
+  }
+
+  function allUniqueTags(data) {
+    let tags = {};
+    const { discussions, subjects, userCollections } = data;
+
+    tags = uniqueTags(Object.values(subjects), tags);
 
     for (discussion of Object.values(discussions)) {
-      discussion.comments.forEach(comment => {
-        comment.tags && comment.tags.forEach(tag => {
-          tags[tag] = tag;
-        });
-      })
+      tags = uniqueTags(discussion.comments, tags);
     }
 
-    for (userCollection of Object.values(userCollections)) {
-      userCollection.tags && userCollection.tags.forEach(tag => {
-        tags[tag] = tag;
-      })
-    }
+    tags = uniqueTags(Object.values(userCollections), tags);
 
     return Object.keys(tags);
   }
@@ -107,7 +105,7 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addCollection("taggedContent", collection => {
     const taggedItems = {};
-    const tagNames = uniqueTags(pageData(collection));
+    const tagNames = allUniqueTags(pageData(collection));
     for (tag of tagNames) {
       taggedItems[tag] = buildTagCollection(tag, collection, pageData(collection));
     }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,6 +55,9 @@ module.exports = function(eleventyConfig) {
   // build collections from tagged subjects.
 
   function hasTag(item, tag) {
+    if (item.tags && item.tags.indexOf(tag) > -1) {
+      return true;
+    }
     const matchingTags = item.tags && item.tags.filter(itemTag => tag === itemTag._id);
     return matchingTags && matchingTags.length > 0;
   }
@@ -67,7 +70,7 @@ module.exports = function(eleventyConfig) {
 
   function uniqueTags(data) {
     const tags = {};
-    const { discussions, subjects } = data;
+    const { discussions, subjects, userCollections } = data;
 
     for (subject of Object.values(subjects)) {
       subject.tags && subject.tags.forEach(tag => {
@@ -82,18 +85,24 @@ module.exports = function(eleventyConfig) {
         });
       })
     }
+
+    for (userCollection of Object.values(userCollections)) {
+      userCollection.tags && userCollection.tags.forEach(tag => {
+        tags[tag] = tag;
+      })
+    }
+
     return Object.keys(tags);
   }
 
   function buildTagCollection(tag, collection, data) {
     const subjects = Object.values(data.subjects).filter(subject => hasTag(subject, tag));
     const discussions = Object.values(data.discussions).filter(discussion => {
-      const taggedComments = discussion.comments.filter(comment => {
-        return comment.tags && comment.tags.indexOf(tag) > -1;
-      });
+      const taggedComments = discussion.comments.filter(comment => hasTag(comment, tag));
       return taggedComments.length > 0;
     });
-    return { discussions, subjects };
+    const userCollections = Object.values(data.userCollections).filter(userCollection => hasTag(userCollection, tag));
+    return { discussions, subjects, userCollections };
   }
 
   eleventyConfig.addCollection("taggedContent", collection => {

--- a/src/site/subjects/subject.njk
+++ b/src/site/subjects/subject.njk
@@ -14,6 +14,12 @@ renderData:
 <div class="container">
   <img class="subject" src={{ subject.location.standard }} >
 
+  <h2>Tags</h2>
+  <ul>
+    {% for tag in subject.tags %}
+      <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
+    {% endfor %}
+  </ul>
   <h2>Comments</h2>
   <ul>
   {%- for comment in subject.discussion.comments | reverse -%}

--- a/src/site/tags/collections.njk
+++ b/src/site/tags/collections.njk
@@ -1,0 +1,28 @@
+---
+layout: default
+pagination:
+  data: collections.taggedContent
+  size: 1
+  alias: tag
+permalink: "/tags/{{ tag }}/collections.html"
+renderData:
+  title: "{{ tag }}"
+---
+<h1>Tag: {{ tag }}</h1>
+<h2>Collections</h2>
+<ul>
+  {% for collection in collections.taggedContent[tag].userCollections %}
+    <li>
+      <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
+      <ul class="collection">
+        {%- for collectionSubject in collection.subjects | limit(4) -%}
+          <li id={{ collectionSubject.zooniverse_id }} class="subject">
+            <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
+              <img src={{ collectionSubject.location.thumb}}>
+            </a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    </li>
+  {% endfor %}
+</ul>

--- a/src/site/tags/discussions.njk
+++ b/src/site/tags/discussions.njk
@@ -4,23 +4,14 @@ pagination:
   data: collections.taggedContent
   size: 1
   alias: tag
-permalink: "/tags/{{ tag }}/"
+permalink: "/tags/{{ tag }}/discussions.html"
 renderData:
   title: "{{ tag }}"
 ---
 <h1>Tag: {{ tag }}</h1>
-<h2><a href="/tags/{{ tag }}/subjects.html">Subjects</a></h2>
-<ul class="collection">
-  {% for subject in collections.taggedContent[tag].subjects | limit(6) %}
-    <li id={{ subject.zooniverse_id }} class="subject">
-      <a href="/subjects/{{ subject.zooniverse_id }}"><img src={{ subject.location.thumb}}></a> 
-    </li>
-  {% endfor %}
-</ul>
-
-<h2><a href="/tags/{{ tag }}/discussions.html">Discussions</a></h2>
+<h2>Discussions</h2>
 <ul>
-  {% for discussion in collections.taggedContent[tag].discussions | limit(6) %}
+  {% for discussion in collections.taggedContent[tag].discussions %}
     <li>
       <p><a href="/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id}}/">{{ discussion.title }}</a></p>
       <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>

--- a/src/site/tags/subjects.njk
+++ b/src/site/tags/subjects.njk
@@ -1,0 +1,19 @@
+---
+layout: default
+pagination:
+  data: collections.taggedContent
+  size: 1
+  alias: tag
+permalink: "/tags/{{ tag }}/subjects.html"
+renderData:
+  title: "{{ tag }}"
+---
+<h1>Tag: {{ tag }}</h1>
+<h2>Subjects</h2>
+<ul class="collection">
+  {% for subject in collections.taggedContent[tag].subjects %}
+    <li id={{ subject.zooniverse_id }} class="subject">
+      <a href="/subjects/{{ subject.zooniverse_id }}"><img src={{ subject.location.thumb}}></a> 
+    </li>
+  {% endfor %}
+</ul>

--- a/src/site/tags/tag.njk
+++ b/src/site/tags/tag.njk
@@ -29,3 +29,22 @@ renderData:
     </li>
   {% endfor %}
 </ul>
+
+<h2><a href="/tags/{{ tag }}/collections.html">Collections</a></h2>
+<ul>
+  {% for collection in collections.taggedContent[tag].userCollections | limit(6) %}
+    <li>
+      <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
+      <ul class="collection">
+        {%- for collectionSubject in collection.subjects | limit(4) -%}
+          <li id={{ collectionSubject.zooniverse_id }} class="subject">
+            <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
+              <img src={{ collectionSubject.location.thumb}}>
+            </a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    </li>
+  {% endfor %}
+</ul>
+

--- a/src/site/tags/tag.njk
+++ b/src/site/tags/tag.njk
@@ -9,7 +9,7 @@ renderData:
   title: "{{ tag }}"
 ---
 <h1>Tag: {{ tag }}</h1>
-<h2><a href="/tags/{{ tag }}/subjects.html">Subjects</a></h2>
+<h2><a href="/tags/{{ tag }}/subjects.html">Subjects</a> ({{ collections.taggedContent[tag].subjects.length }})</h2>
 <ul class="collection">
   {% for subject in collections.taggedContent[tag].subjects | limit(6) %}
     <li id={{ subject.zooniverse_id }} class="subject">
@@ -18,7 +18,7 @@ renderData:
   {% endfor %}
 </ul>
 
-<h2><a href="/tags/{{ tag }}/discussions.html">Discussions</a></h2>
+<h2><a href="/tags/{{ tag }}/discussions.html">Discussions</a> ({{ collections.taggedContent[tag].discussions.length }})</h2>
 <ul>
   {% for discussion in collections.taggedContent[tag].discussions | limit(6) %}
     <li>
@@ -30,7 +30,7 @@ renderData:
   {% endfor %}
 </ul>
 
-<h2><a href="/tags/{{ tag }}/collections.html">Collections</a></h2>
+<h2><a href="/tags/{{ tag }}/collections.html">Collections</a> ({{ collections.taggedContent[tag].userCollections.length }})</h2>
 <ul>
   {% for collection in collections.taggedContent[tag].userCollections | limit(6) %}
     <li>

--- a/src/site/tags/tag.njk
+++ b/src/site/tags/tag.njk
@@ -1,0 +1,19 @@
+---
+layout: default
+pagination:
+  data: collections.taggedContent
+  size: 1
+  alias: tag
+permalink: "/tags/{{ tag }}/"
+renderData:
+  title: "{{ tag }}"
+---
+<h1>Tag: {{ tag }}</h1>
+<h2><a href="/tags/{{ tag }}/subjects.html">Subjects</a></h2>
+<ul class="collection">
+  {% for subject in collections.taggedContent[tag].subjects | limit(6) %}
+    <li id={{ subject.zooniverse_id }} class="subject">
+      <a href="/subjects/{{ subject.zooniverse_id }}"><img src={{ subject.location.thumb}}></a> 
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
Add `collections.taggedContent` which contains tagged subjects, discussions and collections, organised by tag. Add pages to list all tagged content by type, for a given tag, plus an overall summary page for each tag.