### PR TITLE
Subject page grid and content pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,7 +49,7 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.addFilter("limit", (array, limit) => {
-    return array.slice(0, limit);
+    return (array && array.slice) ? array.slice(0, limit) : array;
   });
 
   eleventyConfig.addFilter("focus", (discussions, focusID) => {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -28,6 +28,11 @@ p {
   @apply mb-2;
 }
 
+.subject-page {
+  @apply grid;
+  grid-template-columns: 1fr 2fr;
+}
+
 .collection {
   @apply max-w-6xl mx-auto;
 }
@@ -40,16 +45,8 @@ p {
   @apply h-full;
 }
 
-.container {
-  @apply max-w-3xl mx-auto;
-}
-
 .comment {
   @apply mb-4 border-b;
-}
-
-.focus {
-  @apply float-left w-1/3;
 }
 
 .focus img {

--- a/src/site/_includes/layouts/default.njk
+++ b/src/site/_includes/layouts/default.njk
@@ -8,10 +8,10 @@
     <title>{{ renderData.title or title }}</title>
     <meta name="description" content="{{ renderData.description or description }}">
   </head>
-  <body>
-    <div class="container mt-8 mb-8">
-      <h1 class="text-5xl">Science Gossip</h1>
-    </div>
+  <body class="container mx-auto">
+    <header>
+      <h1>Science Gossip</h1>
+    </header>
     {{ content | safe }}
     <script src="{% webpackAsset 'main.js' %}"></script>
   </body>

--- a/src/site/discussions/discussion.md
+++ b/src/site/discussions/discussion.md
@@ -10,13 +10,16 @@ renderData:
   title: "{{ discussion.title}}"
   description: "{{ discussion.description }}"
 ---
-<h1 class="text-lg">{{ discussion.title }}</h1>
-<p>{{ discussion.description }}</p>
-{% if discussion.focus and discussion.focus.base_type == 'Subject' %}
+<div class="subject-page">
 <div class="focus container">
-  <a href="/subjects/{{ discussion.focus.zooniverse_id }}"><img alt="Subject {{ discussion.focus.zooniverse_id }}" src={{ discussion.focus.location.standard }}></a>
-</div>
+{% if discussion.focus and discussion.focus.base_type == 'Subject' %}
+<a href="/subjects/{{ discussion.focus.zooniverse_id }}">{{ discussion.focus.zooniverse_id }}</a>
+<a href="/subjects/{{ discussion.focus.zooniverse_id }}"><img alt="Subject {{ discussion.focus.zooniverse_id }}" src={{ discussion.focus.location.standard }}></a>
 {% endif %}
+</div>
+<div>
+<h1>{{ discussion.title }}</h1>
+<p>{{ discussion.description }}</p>
 <ul class="container">
 {%- for comment in discussion.comments -%}
 <li id={{ comment._id }} class="comment">
@@ -28,3 +31,5 @@ Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</
 </li>
 {%- endfor -%}
 </ul>
+</div>
+</div>

--- a/src/site/subjects/collections.njk
+++ b/src/site/subjects/collections.njk
@@ -1,0 +1,55 @@
+---
+layout: default
+pagination:
+  data: subjects
+  resolve: values
+  size: 1
+  alias: subject
+permalink: "/subjects/{{ subject.zooniverse_id }}/collections.html"
+renderData:
+  title: "Subject {{ subject.zooniverse_id }}: Collections"
+---
+<h1 class="text-lg"><a href="/subjects/{{ subject.zooniverse_id }}">{{ subject.zooniverse_id }}</a></h1>
+
+<div class=" focus container">
+  <img class="subject" src={{ subject.location.standard }} >
+
+  <h2>Comments</h2>
+  <ul>
+  {%- for comment in subject.discussion.comments | reverse -%}
+  <li id={{ comment._id }} class="comment">
+    <a href="/users/{{ comment.user_name }}">
+      <img width=20 height=20 src="https://api.zooniverse.org/talk/avatars/{{ comment.user_zooniverse_id }}" class="avatar" onerror="window.defaultAvatar(this)"></a> by <a href="/users/{{ comment.user_name }}">{{ comment.user_name }}
+      </a>
+      {% if comment.response_to %}
+        <a href="#{{ comment.response_to._id }}">in response to {{ comment.response_to.user_name}}'s comment.</a>
+      {% endif %}
+
+      {{ comment.body | safe }}
+
+      Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
+  </li>
+  {%- endfor -%}
+  </ul>
+</div>
+
+<div class="container">
+
+  <h2>Collections</h2>
+  <ul>
+    {%- for collection in subject.collections -%}
+      <li>
+        <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
+        <ul class="collection">
+          {%- for collectionSubject in collection.subjects | limit(4) -%}
+            <li id={{ collectionSubject.zooniverse_id }} class="subject">
+              <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
+                <img src={{ collectionSubject.location.thumb}}>
+              </a>
+            </li>
+          {%- endfor -%}
+        </ul>
+      </li>
+    {%- endfor -%}
+  </ul>
+</div>

--- a/src/site/subjects/collections.njk
+++ b/src/site/subjects/collections.njk
@@ -9,47 +9,50 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/collections.html"
 renderData:
   title: "Subject {{ subject.zooniverse_id }}: Collections"
 ---
-<h1 class="text-lg"><a href="/subjects/{{ subject.zooniverse_id }}">{{ subject.zooniverse_id }}</a></h1>
+<div class="subject-page">
+  <div class=" focus container">
+    <h1 class="text-lg">
+      <a href="/subjects/{{ subject.zooniverse_id }}">{{ subject.zooniverse_id }}</a>
+    </h1>
+    <img class="subject" src={{ subject.location.standard }} >
 
-<div class=" focus container">
-  <img class="subject" src={{ subject.location.standard }} >
+    <h2>Comments</h2>
+    <ul>
+    {%- for comment in subject.discussion.comments | reverse -%}
+    <li id={{ comment._id }} class="comment">
+      <a href="/users/{{ comment.user_name }}">
+        <img width=20 height=20 src="https://api.zooniverse.org/talk/avatars/{{ comment.user_zooniverse_id }}" class="avatar" onerror="window.defaultAvatar(this)"></a> by <a href="/users/{{ comment.user_name }}">{{ comment.user_name }}
+        </a>
+        {% if comment.response_to %}
+          <a href="#{{ comment.response_to._id }}">in response to {{ comment.response_to.user_name}}'s comment.</a>
+        {% endif %}
 
-  <h2>Comments</h2>
-  <ul>
-  {%- for comment in subject.discussion.comments | reverse -%}
-  <li id={{ comment._id }} class="comment">
-    <a href="/users/{{ comment.user_name }}">
-      <img width=20 height=20 src="https://api.zooniverse.org/talk/avatars/{{ comment.user_zooniverse_id }}" class="avatar" onerror="window.defaultAvatar(this)"></a> by <a href="/users/{{ comment.user_name }}">{{ comment.user_name }}
-      </a>
-      {% if comment.response_to %}
-        <a href="#{{ comment.response_to._id }}">in response to {{ comment.response_to.user_name}}'s comment.</a>
-      {% endif %}
+        {{ comment.body | safe }}
 
-      {{ comment.body | safe }}
-
-      Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
-  </li>
-  {%- endfor -%}
-  </ul>
-</div>
-
-<div class="container">
-
-  <h2>Collections</h2>
-  <ul>
-    {%- for collection in subject.collections -%}
-      <li>
-        <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
-        <ul class="collection">
-          {%- for collectionSubject in collection.subjects | limit(4) -%}
-            <li id={{ collectionSubject.zooniverse_id }} class="subject">
-              <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                <img src={{ collectionSubject.location.thumb}}>
-              </a>
-            </li>
-          {%- endfor -%}
-        </ul>
-      </li>
+        Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
+    </li>
     {%- endfor -%}
-  </ul>
+    </ul>
+  </div>
+
+  <div class="container">
+
+    <h2>Collections</h2>
+    <ul>
+      {%- for collection in subject.collections -%}
+        <li>
+          <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
+          <ul class="collection">
+            {%- for collectionSubject in collection.subjects | limit(4) -%}
+              <li id={{ collectionSubject.zooniverse_id }} class="subject">
+                <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
+                  <img src={{ collectionSubject.location.thumb}}>
+                </a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </li>
+      {%- endfor -%}
+    </ul>
+  </div>
 </div>

--- a/src/site/subjects/subject.njk
+++ b/src/site/subjects/subject.njk
@@ -9,68 +9,69 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/"
 renderData:
   title: "Subject {{ subject.zooniverse_id }}"
 ---
-<h1 class="text-lg">{{ subject.zooniverse_id }}</h1>
+<div class="subject-page">
+  <div class=" focus container">
+    <h1 class="text-lg">{{ subject.zooniverse_id }}</h1>
+    <img class="subject" src={{ subject.location.standard }} >
 
-<div class=" focus container">
-  <img class="subject" src={{ subject.location.standard }} >
-
-  <h2>Comments</h2>
-  <ul>
-  {%- for comment in subject.discussion.comments | reverse -%}
-  <li id={{ comment._id }} class="comment">
-    <a href="/users/{{ comment.user_name }}">
-      <img width=20 height=20 src="https://api.zooniverse.org/talk/avatars/{{ comment.user_zooniverse_id }}" class="avatar" onerror="window.defaultAvatar(this)"></a> by <a href="/users/{{ comment.user_name }}">{{ comment.user_name }}
-      </a> 
-      {% if comment.response_to %}
-        <a href="#{{ comment.response_to._id }}">in response to {{ comment.response_to.user_name}}'s comment.</a>
-      {% endif %}
-
-      {{ comment.body | safe }}
-
-      Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
-  </li>
-  {%- endfor -%}
-  </ul>
-</div>
-
-<div class="container">
-  <h2>Tags</h2>
-  <ul>
-    {% for tag in subject.tags %}
-      <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
-    {% endfor %}
-  </ul>
-
-  <h2><a href="./collections.html">Collections</a></h2>
-  <ul>
-    {%- for collection in subject.collections | limit(3) -%}
-      <li>
-        <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
-        <ul class="collection">
-          {%- for collectionSubject in collection.subjects | limit(4) -%}
-            <li id={{ collectionSubject.zooniverse_id }} class="subject">
-              <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                <img src={{ collectionSubject.location.thumb}}>
-              </a>
-            </li>
-          {%- endfor -%}
-        </ul>
-      </li>
-    {%- endfor -%}
-  </ul>
-
-  <h2>Board Discussions</h2>
-  {% for category, categoryDiscussions in discussions | focus(subject.zooniverse_id) %}
-    <h3>{{ category | capitalize }}</h3>
+    <h2>Comments</h2>
     <ul>
-      {% for discussion in categoryDiscussions %}
-        <li>
-          <p><a href="/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id}}/">{{ discussion.title }}</a></p>
-          <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
-          <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
-          <hr>
-        </li>
-      {% endfor  %}
+    {%- for comment in subject.discussion.comments | reverse -%}
+    <li id={{ comment._id }} class="comment">
+      <a href="/users/{{ comment.user_name }}">
+        <img width=20 height=20 src="https://api.zooniverse.org/talk/avatars/{{ comment.user_zooniverse_id }}" class="avatar" onerror="window.defaultAvatar(this)"></a> by <a href="/users/{{ comment.user_name }}">{{ comment.user_name }}
+        </a> 
+        {% if comment.response_to %}
+          <a href="#{{ comment.response_to._id }}">in response to {{ comment.response_to.user_name}}'s comment.</a>
+        {% endif %}
+
+        {{ comment.body | safe }}
+
+        Posted <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
+    </li>
+    {%- endfor -%}
     </ul>
-  {% endfor %}
+  </div>
+
+  <div class="container">
+    <h2>Tags</h2>
+    <ul>
+      {% for tag in subject.tags %}
+        <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
+      {% endfor %}
+    </ul>
+
+    <h2><a href="./collections.html">Collections</a></h2>
+    <ul>
+      {%- for collection in subject.collections | limit(3) -%}
+        <li>
+          <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
+          <ul class="collection">
+            {%- for collectionSubject in collection.subjects | limit(4) -%}
+              <li id={{ collectionSubject.zooniverse_id }} class="subject">
+                <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
+                  <img src={{ collectionSubject.location.thumb}}>
+                </a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </li>
+      {%- endfor -%}
+    </ul>
+
+    <h2>Board Discussions</h2>
+    {% for category, categoryDiscussions in discussions | focus(subject.zooniverse_id) %}
+      <h3>{{ category | capitalize }}</h3>
+      <ul>
+        {% for discussion in categoryDiscussions %}
+          <li>
+            <p><a href="/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id}}/">{{ discussion.title }}</a></p>
+            <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+            <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+            <hr>
+          </li>
+        {% endfor  %}
+      </ul>
+    {% endfor %}
+  </div>
 </div>

--- a/src/site/subjects/subject.njk
+++ b/src/site/subjects/subject.njk
@@ -13,15 +13,7 @@ renderData:
 
 <div class=" focus container">
   <img class="subject" src={{ subject.location.standard }} >
-</div>
 
-<div class="container">
-  <h2>Tags</h2>
-  <ul>
-    {% for tag in subject.tags %}
-      <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
-    {% endfor %}
-  </ul>
   <h2>Comments</h2>
   <ul>
   {%- for comment in subject.discussion.comments | reverse -%}
@@ -39,12 +31,21 @@ renderData:
   </li>
   {%- endfor -%}
   </ul>
+</div>
 
-  <h2>Collections</h2>
+<div class="container">
+  <h2>Tags</h2>
   <ul>
-    {%- for collection in subject.collections -%}
+    {% for tag in subject.tags %}
+      <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
+    {% endfor %}
+  </ul>
+
+  <h2><a href="./collections.html">Collections</a></h2>
+  <ul>
+    {%- for collection in subject.collections | limit(3) -%}
       <li>
-        <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
+        <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.user_name }}: {{ collection.title }}</a></p>
         <ul class="collection">
           {%- for collectionSubject in collection.subjects | limit(4) -%}
             <li id={{ collectionSubject.zooniverse_id }} class="subject">

--- a/src/site/users/collections.njk
+++ b/src/site/users/collections.njk
@@ -1,0 +1,28 @@
+---
+layout: default
+pagination:
+  data: users
+  resolve: values
+  size: 1
+  alias: user
+permalink: "/users/{{ user.name | slug }}/collections.html"
+renderData:
+  title: "{{ user.name }} collections"
+---
+<h1><a href="/users/{{ user.name }}">{{ user.name }}</a></h1>
+
+<h2>Collections ({{ user.my_collections.length }})</h2>
+<ul>
+{%- for collection in user.my_collections -%}
+  <li>
+    <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
+    <ul class="collection">
+      {%- for subject in collection.subjects | limit(4) -%}
+        <li id={{ subject.zooniverse_id }} class="subject">
+          <a href="/subjects/{{ subject.zooniverse_id }}"><img src={{ subject.location.thumb}}></a>
+        </li>
+      {%- endfor -%}
+    </ul>
+  </li>
+{%- endfor -%}
+</ul>

--- a/src/site/users/comments.njk
+++ b/src/site/users/comments.njk
@@ -1,0 +1,29 @@
+---
+layout: default
+pagination:
+  data: users
+  resolve: values
+  size: 1
+  alias: user
+permalink: "/users/{{ user.name | slug }}/comments.html"
+renderData:
+  title: "{{ user.name }} comments"
+---
+<h1><a href="/users/{{ user.name }}">{{ user.name }}</a></h1>
+
+<h2>Subject comments ({{ user.subjects.length }})</h2>
+<ul class="collection">
+{%- for subject in user.subjects -%}
+  <li id={{ subject.focus.zooniverse_id }} class="subject">
+    <a href="/subjects/{{ subject.focus.zooniverse_id }}">
+      <img src={{ subject.focus.location.thumb}}>
+    </a>
+    <p>
+      {{ subject.comment.body }}
+    </p>
+    <time datetime={{ comment.created_at }}>{{ comment.created_at | date }}</time>
+  </li>
+{%- endfor -%}
+</ul>
+<h2>Collectionsb({{ user.my_collections.length }})</h2>
+<ul>

--- a/src/site/users/user.njk
+++ b/src/site/users/user.njk
@@ -9,11 +9,11 @@ permalink: "/users/{{ user.name | slug }}/"
 renderData:
   title: "{{ user.name }}"
 ---
-<h1 class="text-lg">{{ user.name }}</h1>
+<h1>{{ user.name }}</h1>
 
-<h2>Subject comments ({{ user.subjects.length }})</h2>
+<h2><a href="./comments.html">Subject comments ({{ user.subjects.length }})</a></h2>
 <ul class="collection">
-{%- for subject in user.subjects -%}
+{%- for subject in user.subjects | limit(5) -%}
   <li id={{ subject.focus.zooniverse_id }} class="subject">
     <a href="/subjects/{{ subject.focus.zooniverse_id }}">
       <img src={{ subject.focus.location.thumb}}>
@@ -25,9 +25,9 @@ renderData:
   </li>
 {%- endfor -%}
 </ul>
-<h2>Collectionsb({{ user.my_collections.length }})</h2>
+<h2><a href="./collections.html">Collections ({{ user.my_collections.length }})</a></h2>
 <ul>
-{%- for collection in user.my_collections -%}
+{%- for collection in user.my_collections | limit(3) -%}
   <li>
     <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
     <ul class="collection">


### PR DESCRIPTION
Add the `1:2` column grid for subjects and subject discussions.
Add pages with full lists for collections and subject comments.