### PR TITLE
Add featured and pinned discussions

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,6 +65,14 @@ module.exports = function(eleventyConfig) {
     return boards;
   });
 
+  eleventyConfig.addFilter("pinned", (discussions, boardID) => {
+    return discussions.filter(discussion => discussion.board._id === boardID);
+  });
+
+  eleventyConfig.addFilter("featured", (discussions, boardID) => {
+    return discussions.filter(discussion => discussion.board._id !== boardID);
+  });
+
   // custom tags
 
   eleventyConfig.addShortcode('avatar', (username, url) => {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -73,6 +73,11 @@ module.exports = function(eleventyConfig) {
     return discussions.filter(discussion => discussion.board._id !== boardID);
   });
 
+  eleventyConfig.addFilter("notFeatured", (discussionIDs, featured) => {
+    const featuredIDs = featured.map(discussion => discussion.zooniverse_id);
+    return discussionIDs.filter(discussionID => featuredIDs.indexOf(discussionID) === -1);
+  });
+
   // custom tags
 
   eleventyConfig.addShortcode('avatar', (username, url) => {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -57,6 +57,10 @@ p {
   @apply max-w-sm
 }
 
+.pinned-discussion:before {
+  content: "\1f4cc";
+}
+
 .tag-list {
   @apply grid grid-cols-3 grid-flow-row;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -28,7 +28,7 @@ p {
   @apply mb-2;
 }
 
-.subject-page {
+.page-grid {
   @apply grid;
   grid-template-columns: 1fr 2fr;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -29,7 +29,7 @@ p {
 }
 
 .page-grid {
-  @apply grid;
+  @apply grid gap-2;
   grid-template-columns: 1fr 2fr;
 }
 

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -57,4 +57,7 @@ p {
   @apply max-w-sm
 }
 
+.tag-list {
+  @apply grid grid-cols-3 grid-flow-row;
+}
 @tailwind utilities;

--- a/src/helpers/fetchBoards.js
+++ b/src/helpers/fetchBoards.js
@@ -13,7 +13,6 @@ async function discussionBoard(board) {
     const discussionsCount = board.discussions_count || board.discussions;
     const pages = Math.ceil(discussionsCount / 10) || 1
     const fullBoard = await fetchBoard(board, pages);
-    console.log('board discussions', board.zooniverse_id, discussionsCount);
     boards[fullBoard.category] = boards[fullBoard.category] || {};
     boards[fullBoard.category][board.zooniverse_id] = fullBoard;
   }
@@ -23,9 +22,10 @@ async function discussionBoard(board) {
 module.exports = async function fetchBoards() {
   const boards = await API.get('boards/');
   for (category of CATEGORIES) {
-    console.log(category)
     const categoryBoards = await Promise.all(boards[category].map(discussionBoard));
     boards[category] = categoryBoards;
   }
-  return boards;
+  store.boards.featured = boards.featured;
+  store.boards.tags = boards.tags;
+  return store.boards;
 }

--- a/src/site/_includes/layouts/default.njk
+++ b/src/site/_includes/layouts/default.njk
@@ -10,7 +10,7 @@
   </head>
   <body class="container mx-auto">
     <header>
-      <h1>Science Gossip</h1>
+      <a href="/boards">Science Gossip Talk</a>
     </header>
     {{ content | safe }}
     <script src="{% webpackAsset 'main.js' %}"></script>

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -49,7 +49,7 @@ renderData:
     </ul>
 
     <ul class="container">
-      {%- for discussionID in board.links.discussions -%}
+      {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
         <li>
           <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
           <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -15,7 +15,7 @@ renderData:
   <div>
     <h2>Featured chat discussions</h2>
     <ul>
-    {% for discussion in board.featured %}
+    {% for discussion in board.featured | featured(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
         <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
@@ -37,6 +37,16 @@ renderData:
     <h2>{{ board.title }}</h2>
     <p>{{ board.description }}</p>
     <p>{{ board.links.discussions.length }} conversations</p>
+
+    <ul>
+    {% for discussion in board.featured | pinned(board.zooniverse_id) %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
 
     <ul class="container">
       {%- for discussionID in board.links.discussions -%}

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -14,6 +14,15 @@ renderData:
 <div class="page-grid">
   <div>
     <h2>Featured chat discussions</h2>
+    <ul>
+    {% for discussion in board.featured %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <div>
     <h2>{{ board.title }}</h2>
@@ -26,7 +35,6 @@ renderData:
           <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
           <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
           <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
-          <hr>
         </li>
       {%- endfor -%}
     </ul>

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -18,7 +18,7 @@ renderData:
     {% for discussion in board.featured | featured(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
-        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>
     {% endfor %}

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -10,17 +10,25 @@ renderData:
   title: "{{ board.title }}"
   description: "{{ board.description }}"
 ---
-<h1>{{ board.title }}</h1>
-<p>{{ board.description }}</p>
-<p>{{ board.links.discussions.length }} conversations</p>
+<h1>Chat Board</h1>
+<div class="page-grid">
+  <div>
+    <h2>Featured chat discussions</h2>
+  </div>
+  <div>
+    <h2>{{ board.title }}</h2>
+    <p>{{ board.description }}</p>
+    <p>{{ board.links.discussions.length }} conversations</p>
 
-<ul class="container">
-  {%- for discussionID in board.links.discussions -%}
-    <li>
-      <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-      <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-      <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
-      <hr>
-    </li>
-  {%- endfor -%}
-</ul>
+    <ul class="container">
+      {%- for discussionID in board.links.discussions -%}
+        <li>
+          <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
+          <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
+          <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+          <hr>
+        </li>
+      {%- endfor -%}
+    </ul>
+  </div>
+</div>

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -23,6 +23,15 @@ renderData:
       </li>
     {% endfor %}
     </ul>
+
+    <h2>Popular hashtags</h2>
+    <ul class="tag-list">
+    {% for tag in board.tags %}
+      <li>
+        <a href="/tags/{{ tag._id }}">{{ tag._id }}</a>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <div>
     <h2>{{ board.title }}</h2>

--- a/src/site/boards/chat.njk
+++ b/src/site/boards/chat.njk
@@ -41,7 +41,9 @@ renderData:
     <ul>
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p class="pinned-discussion">
+          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
+        </p>
         <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -41,8 +41,10 @@ renderData:
     <ul>
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
-        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
+        <p class="pinned-discussion">
+          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
+        </p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>
     {% endfor %}

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -49,7 +49,7 @@ renderData:
     </ul>
 
     <ul class="container">
-      {%- for discussionID in board.links.discussions -%}
+      {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
         <li>
           <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
           <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -10,17 +10,25 @@ renderData:
   title: "{{ board.title }}"
   description: "{{ board.description }}"
 ---
-<h1>{{ board.title }}</h1>
-<p>{{ board.description }}</p>
-<p>{{ board.links.discussions.length }} conversations</p>
+<h1>Help Board</h1>
+<div class="page-grid">
+  <div>
+    <h2>Featured help discussions</h2>
+  </div>
+  <div>
+    <h2>{{ board.title }}</h2>
+    <p>{{ board.description }}</p>
+    <p>{{ board.links.discussions.length }} conversations</p>
 
-<ul class="container">
-  {%- for discussionID in board.links.discussions -%}
-    <li>
-      <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-      <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-      <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
-      <hr>
-    </li>
-  {%- endfor -%}
-</ul>
+    <ul class="container">
+      {%- for discussionID in board.links.discussions -%}
+        <li>
+          <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
+          <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
+          <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+          <hr>
+        </li>
+      {%- endfor -%}
+    </ul>
+  </div>
+</div>

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -14,6 +14,15 @@ renderData:
 <div class="page-grid">
   <div>
     <h2>Featured help discussions</h2>
+    <ul>
+    {% for discussion in board.featured %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <div>
     <h2>{{ board.title }}</h2>

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -42,7 +42,7 @@ renderData:
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
-        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>
     {% endfor %}

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -23,6 +23,15 @@ renderData:
       </li>
     {% endfor %}
     </ul>
+
+    <h2>Popular hashtags</h2>
+    <ul class="tag-list">
+    {% for tag in board.tags %}
+      <li>
+        <a href="/tags/{{ tag._id }}">{{ tag._id }}</a>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <div>
     <h2>{{ board.title }}</h2>

--- a/src/site/boards/help.njk
+++ b/src/site/boards/help.njk
@@ -15,7 +15,7 @@ renderData:
   <div>
     <h2>Featured help discussions</h2>
     <ul>
-    {% for discussion in board.featured %}
+    {% for discussion in board.featured | featured(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
         <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
@@ -37,6 +37,16 @@ renderData:
     <h2>{{ board.title }}</h2>
     <p>{{ board.description }}</p>
     <p>{{ board.links.discussions.length }} conversations</p>
+
+    <ul>
+    {% for discussion in board.featured | pinned(board.zooniverse_id) %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
 
     <ul class="container">
       {%- for discussionID in board.links.discussions -%}

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -2,6 +2,7 @@
 title: Discussion boards
 layout: default
 ---
+<h1>Discussion Boards</h1>
 <div class="page-grid">
   <div>
     <h2>Featured discussions</h2>

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -2,20 +2,50 @@
 title: Discussion boards
 layout: default
 ---
-<ul>
-  {%- for category, categoryBoards in boards -%}
-  <li>
-    <h2>{{ category | capitalize }}</h2>
-    <hr>
-    <ul class="container">
-      {%- for boardID, board in categoryBoards -%}
-        <li>
-          <p><a href="./{{ boardID }}">{{ board.title }}</a></p>
-          <p>{{ board.description }}</p>
-          <hr>
-        </li>
-      {%- endfor -%}
-    </ul>
-  </li>
-  {%- endfor -%}
-</ul>
+<div class="page-grid">
+  <div>
+    <h2>Featured discussions</h2>
+    {{ boards.featured | dump }}
+  </div>
+  <ul>
+    <li>
+      <h2>Help</h2>
+      <hr>
+      <ul class="container">
+        {% for boardID, board in boards.help %}
+          <li>
+            <p><a href="./{{ boardID }}">{{ board.title }}</a></p>
+            <p>{{ board.description }}</p>
+            <hr>
+          </li>
+        {% endfor %}
+      </ul>
+    </li>
+    <li>
+      <h2>Research</h2>
+      <hr>
+      <ul class="container">
+        {% for boardID, board in boards.science %}
+          <li>
+            <p><a href="./{{ boardID }}">{{ board.title }}</a></p>
+            <p>{{ board.description }}</p>
+            <hr>
+          </li>
+        {% endfor %}
+      </ul>
+    </li>
+    <li>
+      <h2>Chat</h2>
+      <hr>
+      <ul class="container">
+        {% for boardID, board in boards.chat %}
+          <li>
+            <p><a href="./{{ boardID }}">{{ board.title }}</a></p>
+            <p>{{ board.description }}</p>
+            <hr>
+          </li>
+        {% endfor %}
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/src/site/boards/index.njk
+++ b/src/site/boards/index.njk
@@ -6,7 +6,24 @@ layout: default
 <div class="page-grid">
   <div>
     <h2>Featured discussions</h2>
-    {{ boards.featured | dump }}
+    <ul>
+    {% for discussion in boards.featured %}
+      <li>
+        <p><a href="/boards/{{ discussion.board._id }}/discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
+
+    <h2>Popular hashtags</h2>
+    <ul class="tag-list">
+    {% for tag in boards.tags %}
+      <li>
+        <a href="/tags/{{ tag._id }}">{{ tag._id }}</a>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <ul>
     <li>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -42,8 +42,10 @@ renderData:
     <ul>
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
-        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
+        <p class="pinned-discussion">
+          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
+        </p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>
     {% endfor %}

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -10,17 +10,25 @@ renderData:
   title: "{{ board.title }}"
   description: "{{ board.description }}"
 ---
-<h1>{{ board.title }}</h1>
-<p>{{ board.description }}</p>
-<p>{{ board.links.discussions.length }} conversations</p>
+<h1>Research Board</h1>
+<div class="page-grid">
+  <div>
+    <h2>Featured research discussions</h2>
+  </div>
+  <div>
+    <h2>{{ board.title }}</h2>
+    <p>{{ board.description }}</p>
+    <p>{{ board.links.discussions.length }} conversations</p>
 
-<ul class="container">
-  {%- for discussionID in board.links.discussions -%}
-    <li>
-      <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-      <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-      <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
-      <hr>
-    </li>
-  {%- endfor -%}
-</ul>
+    <ul class="container">
+      {%- for discussionID in board.links.discussions -%}
+        <li>
+          <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
+          <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
+          <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+          <hr>
+        </li>
+      {%- endfor -%}
+    </ul>
+  </div>
+</div>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -23,7 +23,17 @@ renderData:
       </li>
     {% endfor %}
     </ul>
+
+    <h2>Popular hashtags</h2>
+    <ul class="tag-list">
+    {% for tag in board.tags %}
+      <li>
+        <a href="/tags/{{ tag._id }}">{{ tag._id }}</a>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
+
   <div>
     <h2>{{ board.title }}</h2>
     <p>{{ board.description }}</p>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -14,6 +14,15 @@ renderData:
 <div class="page-grid">
   <div>
     <h2>Featured research discussions</h2>
+    <ul>
+    {% for discussion in board.featured %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
   </div>
   <div>
     <h2>{{ board.title }}</h2>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -15,7 +15,7 @@ renderData:
   <div>
     <h2>Featured research discussions</h2>
     <ul>
-    {% for discussion in board.featured %}
+    {% for discussion in board.featured | featured(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
         <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
@@ -38,6 +38,16 @@ renderData:
     <h2>{{ board.title }}</h2>
     <p>{{ board.description }}</p>
     <p>{{ board.links.discussions.length }} conversations</p>
+
+    <ul>
+    {% for discussion in board.featured | pinned(board.zooniverse_id) %}
+      <li>
+        <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
+        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+      </li>
+    {% endfor %}
+    </ul>
 
     <ul class="container">
       {%- for discussionID in board.links.discussions -%}

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -50,7 +50,7 @@ renderData:
     </ul>
 
     <ul class="container">
-      {%- for discussionID in board.links.discussions -%}
+      {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
         <li>
           <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
           <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>

--- a/src/site/boards/science.njk
+++ b/src/site/boards/science.njk
@@ -43,7 +43,7 @@ renderData:
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
         <p><a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a></p>
-        <p>{{ discussion.comments.length }} posts / {{ discussion.users }} participants</p>
+        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
         <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
       </li>
     {% endfor %}

--- a/src/site/discussions/discussion.md
+++ b/src/site/discussions/discussion.md
@@ -10,7 +10,7 @@ renderData:
   title: "{{ discussion.title}}"
   description: "{{ discussion.description }}"
 ---
-<div class="subject-page">
+<div class="page-grid">
 <div class="focus container">
 {% if discussion.focus and discussion.focus.base_type == 'Subject' %}
 <a href="/subjects/{{ discussion.focus.zooniverse_id }}">{{ discussion.focus.zooniverse_id }}</a>

--- a/src/site/subjects/collections.njk
+++ b/src/site/subjects/collections.njk
@@ -9,7 +9,7 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/collections.html"
 renderData:
   title: "Subject {{ subject.zooniverse_id }}: Collections"
 ---
-<div class="subject-page">
+<div class="page-grid">
   <div class=" focus container">
     <h1 class="text-lg">
       <a href="/subjects/{{ subject.zooniverse_id }}">{{ subject.zooniverse_id }}</a>

--- a/src/site/subjects/subject.njk
+++ b/src/site/subjects/subject.njk
@@ -9,7 +9,7 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/"
 renderData:
   title: "Subject {{ subject.zooniverse_id }}"
 ---
-<div class="subject-page">
+<div class="page-grid">
   <div class=" focus container">
     <h1 class="text-lg">{{ subject.zooniverse_id }}</h1>
     <img class="subject" alt="{{ subject.zooniverse_id }}" src={{ subject.location.standard }} >


### PR DESCRIPTION
Add the default column layout to board listings.
Add individual page headings, and remove the h1 from the default page header.
Add featured projects and tags to the global boards object.
Add featured and pinned discussions to individual board pages.