### PR TITLE
Add comments to collections

### DIFF
--- a/src/api/_data/userCollections.js
+++ b/src/api/_data/userCollections.js
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 
-const API = require('../../helpers/api');
 const store = require('../../helpers/store');
+const discussionComments = require('../../helpers/discussionComments');
 const fetchUsers = require('./users');
 
 module.exports = async function fetchCollections() {
@@ -26,5 +26,14 @@ module.exports = async function fetchCollections() {
       owner.my_collections.push(collection);
     }
   });
+
+  rl.on('close', async () => {
+    const { collections } = await discussionComments;
+    for (discussion of collections) {
+      const collection = store.userCollections[discussion.focus._id];
+      collection.discussion = discussion;
+    }
+  })
+
   return store.userCollections;
 }

--- a/src/helpers/discussionComments.js
+++ b/src/helpers/discussionComments.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+async function discussionComments() {
+/*
+  Read the discussions export and return all discussions filtered by type:
+    - board discussions.
+    - collection comments.
+    - subject comments.
+*/
+  const discussions = [];
+  let boards = [];
+  let collections = [];
+  let subjects = [];
+
+  const rl = readline.createInterface({
+      input: fs.createReadStream(path.resolve(__dirname, '../../.data', 'illustratedlife_discussions.json')),
+      output: process.stdout,
+      terminal: false
+  });
+
+  rl.on('line', (line) => {
+    const discussion = JSON.parse(line);
+    discussions.push(discussion);
+  });
+
+  return new Promise( (resolve, reject) => {
+    rl.on('close', () => {
+      collections = discussions.filter(discussion => !discussion.board._id && discussion.focus.base_type === 'Collection');
+      subjects = discussions.filter(discussion => !discussion.board._id && discussion.focus.base_type === 'Subject');
+      boards = discussions.filter(discussion => !!discussion.board._id);
+      console.log('collection discussions', collections.length)
+      resolve({ boards, collections, subjects });
+    });
+  });
+}
+
+module.exports = discussionComments();


### PR DESCRIPTION
Read discussions from the discussions export and group by type: board, collection or subject discussion. Add collection discussions to collections after reading the collections export.

Closes #21 