### PR TITLE
Treat tags as global data objects

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -78,6 +78,10 @@ module.exports = function(eleventyConfig) {
     return discussionIDs.filter(discussionID => featuredIDs.indexOf(discussionID) === -1);
   });
 
+  eleventyConfig.addFilter('mapKeys', (keys, object) => {
+    return keys.map(key => object[key]);
+  });
+
   // custom tags
 
   eleventyConfig.addShortcode('avatar', require('./src/site/components/avatar'));

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -84,66 +84,6 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addShortcode('featuredDiscussions', require('./src/site/components/featuredDiscussions'));
   eleventyConfig.addShortcode('tags', require('./src/site/components/tagList'));
 
-  // build collections from tagged subjects.
-
-  function hasTag(item, tag) {
-    if (item.tags && item.tags.indexOf(tag) > -1) {
-      return true;
-    }
-    const matchingTags = item.tags && item.tags.filter(itemTag => tag === itemTag._id);
-    return matchingTags && matchingTags.length > 0;
-  }
-
-  function pageData(collection) {
-    const [ item ] = collection.getAll();
-    const { subjects, discussions, userCollections } = item.data;
-    return { subjects, discussions, userCollections };
-  }
-
-  function uniqueTags(items, tags) {
-    for (item of items) {
-      item.tags && item.tags.forEach(tag => {
-        tagName = tag._id || tag;
-        tags[tagName] = tag;
-      });
-    }
-    return tags;
-  }
-
-  function allUniqueTags(data) {
-    let tags = {};
-    const { discussions, subjects, userCollections } = data;
-
-    tags = uniqueTags(Object.values(subjects), tags);
-
-    for (discussion of Object.values(discussions)) {
-      tags = uniqueTags(discussion.comments, tags);
-    }
-
-    tags = uniqueTags(Object.values(userCollections), tags);
-
-    return Object.keys(tags);
-  }
-
-  function buildTagCollection(tag, collection, data) {
-    const subjects = Object.values(data.subjects).filter(subject => hasTag(subject, tag));
-    const discussions = Object.values(data.discussions).filter(discussion => {
-      const taggedComments = discussion.comments.filter(comment => hasTag(comment, tag));
-      return taggedComments.length > 0;
-    });
-    const userCollections = Object.values(data.userCollections).filter(userCollection => hasTag(userCollection, tag));
-    return { name: tag, discussions, subjects, userCollections };
-  }
-
-  eleventyConfig.addCollection("taggedContent", collection => {
-    const taggedItems = {};
-    const tagNames = allUniqueTags(pageData(collection));
-    for (tag of tagNames) {
-      taggedItems[tag] = buildTagCollection(tag, collection, pageData(collection));
-    }
-    return taggedItems;
-  });
-
   // custom markdown setup
   const markdownIt = require("markdown-it");
   const markdownItEmoji = require("markdown-it-emoji");

--- a/src/api/_data/userCollections.js
+++ b/src/api/_data/userCollections.js
@@ -7,33 +7,35 @@ const discussionComments = require('../../helpers/discussionComments');
 const fetchUsers = require('./users');
 
 module.exports = async function fetchCollections() {
-  const users = await fetchUsers();
-  const collections = [];
+  if (Object.keys(store.userCollections).length === 0) {
+    const users = await fetchUsers();
+    const collections = [];
 
-  const rl = readline.createInterface({
-      input: fs.createReadStream(path.resolve(__dirname, '../../../.data', 'illustratedlife_collections.json')),
-      output: process.stdout,
-      terminal: false
-  });
+    const rl = readline.createInterface({
+        input: fs.createReadStream(path.resolve(__dirname, '../../../.data', 'illustratedlife_collections.json')),
+        output: process.stdout,
+        terminal: false
+    });
 
-  rl.on('line', (line) => {
-    const collection = JSON.parse(line);
-    console.log('Read collection', collection.zooniverse_id);
-    store.userCollections[collection.zooniverse_id] = collection;
-    const owner = users[collection.user_name];
-    const collectionExists = owner && owner.my_collections.find(userCollection => userCollection.zooniverse_id === collection.zooniverse_id);
-    if (owner && !collectionExists) {
-      owner.my_collections.push(collection);
-    }
-  });
+    rl.on('line', (line) => {
+      const collection = JSON.parse(line);
+      console.log('Read collection', collection.zooniverse_id);
+      store.userCollections[collection.zooniverse_id] = collection;
+      const owner = users[collection.user_name];
+      const collectionExists = owner && owner.my_collections.find(userCollection => userCollection.zooniverse_id === collection.zooniverse_id);
+      if (owner && !collectionExists) {
+        owner.my_collections.push(collection);
+      }
+    });
 
-  rl.on('close', async () => {
-    const { collections } = await discussionComments;
-    for (discussion of collections) {
-      const collection = store.userCollections[discussion.focus._id];
-      collection.discussion = discussion;
-    }
-  })
+    rl.on('close', async () => {
+      const { collections } = await discussionComments;
+      for (discussion of collections) {
+        const collection = store.userCollections[discussion.focus._id];
+        collection.discussion = discussion;
+      }
+    })
+  }
 
   return store.userCollections;
 }

--- a/src/api/_data/userTags.js
+++ b/src/api/_data/userTags.js
@@ -1,0 +1,7 @@
+const tags = require('../../helpers/tags');
+const userCollections = require('./userCollections');
+
+module.exports = async function() {
+  await userCollections();
+  return tags();
+}

--- a/src/api/templates/tag.njk
+++ b/src/api/templates/tag.njk
@@ -1,0 +1,9 @@
+---
+pagination:
+  data: userTags
+  resolve: values
+  size: 1
+  alias: tag
+permalink: "/userTags/{{ tag.name }}.json"
+---
+{{ tag | dump | safe }}

--- a/src/helpers/store.js
+++ b/src/helpers/store.js
@@ -2,6 +2,7 @@ module.exports = {
   boards: {},
   discussions: {},
   subjects: {},
+  tags: {},
   users: {},
   userCollections: {}
 };

--- a/src/helpers/tags.js
+++ b/src/helpers/tags.js
@@ -1,0 +1,59 @@
+const store = require('./store');
+
+function hasTag(item, tag) {
+  if (item.tags && item.tags.indexOf(tag) > -1) {
+    return true;
+  }
+  const matchingTags = item.tags && item.tags.filter(itemTag => tag === itemTag._id);
+  return matchingTags && matchingTags.length > 0;
+}
+
+function uniqueTags(items, tags) {
+  for (item of items) {
+    item.tags && item.tags.forEach(tag => {
+      tagName = tag._id || tag;
+      tags[tagName] = tag;
+    });
+  }
+  return tags;
+}
+
+function allUniqueTags() {
+  let tags = {};
+  const { discussions, subjects, userCollections } = store;
+
+  tags = uniqueTags(Object.values(subjects), tags);
+
+  for (discussion of Object.values(discussions)) {
+    tags = uniqueTags(discussion.comments, tags);
+  }
+
+  tags = uniqueTags(Object.values(userCollections), tags);
+
+  return Object.keys(tags);
+}
+
+function buildTagCollection(tag) {
+  console.log('building tag', tag);
+  const subjects = Object.values(store.subjects).filter(subject => hasTag(subject, tag));
+  const discussions = Object.values(store.discussions).filter(discussion => {
+    const taggedComments = discussion.comments.filter(comment => hasTag(comment, tag));
+    return taggedComments.length > 0;
+  });
+  const userCollections = Object.values(store.userCollections).filter(userCollection => hasTag(userCollection, tag));
+  return {
+    name: tag,
+    discussions: discussions.map(discussion => discussion.zooniverse_id),
+    subjects: subjects.map(subject => subject.zooniverse_id),
+    userCollections: userCollections.map(collection => collection.zooniverse_id)
+  };
+}
+
+module.exports = function tags() {
+  const tagNames = allUniqueTags();
+  for (tag of tagNames) {
+    store.tags[tag] = buildTagCollection(tag);
+  }
+  return store.tags;
+}
+

--- a/src/site/collections/collection.njk
+++ b/src/site/collections/collection.njk
@@ -18,7 +18,7 @@ renderData:
     <h2>Tags</h2>
     <ul class="tag-list">
       {% for tag in userCollection.tags %}
-        <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
+        <li><a href="/tags/{{ tag._id or tag}}">{{ tag._id or tag }}</a></li>
       {% endfor %}
     </ul>
 

--- a/src/site/subjects/subject.njk
+++ b/src/site/subjects/subject.njk
@@ -49,7 +49,7 @@ renderData:
         <h2>Tags</h2>
         <ul class="tag-list">
           {% for tag in subject.tags %}
-            <li><a href="/tags/{{ tag._id}}">{{ tag._id }}</a></li>
+            <li><a href="/tags/{{ tag._id or tag }}">{{ tag._id or tag }}</a></li>
           {% endfor %}
         </ul>
       </div>

--- a/src/site/tags/collections.njk
+++ b/src/site/tags/collections.njk
@@ -1,7 +1,7 @@
 ---
 layout: default
 pagination:
-  data: collections.taggedContent
+  data: userTags
   resolve: values
   size: 1
   alias: tag

--- a/src/site/tags/collections.njk
+++ b/src/site/tags/collections.njk
@@ -9,13 +9,13 @@ permalink: "/tags/{{ tag.name }}/collections.html"
 renderData:
   title: "Tag: {{ tag.name }}"
   description: "Collections tagged with #{{ tag.name }} on Science Gossip."
-  ogImage: "{{ tag.subjects[0].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>
   <h2>Collections</h2>
   <ul>
-    {% for collection in tag.userCollections %}
+    {% for collection in tag.userCollections | mapKeys(userCollections) %}
       <li>
         <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
         <ul class="collection">

--- a/src/site/tags/discussions.njk
+++ b/src/site/tags/discussions.njk
@@ -1,7 +1,7 @@
 ---
 layout: default
 pagination:
-  data: collections.taggedContent
+  data: userTags
   resolve: values
   size: 1
   alias: tag

--- a/src/site/tags/discussions.njk
+++ b/src/site/tags/discussions.njk
@@ -9,10 +9,10 @@ permalink: "/tags/{{ tag.name }}/discussions.html"
 renderData:
   title: "Tag: {{ tag.name }}"
   description: "Discussions tagged with #{{ tag.name }} on Science Gossip."
-  ogImage: "{{ tag.subjects[0].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>
   <h2>Discussions</h2>
-  {% featuredDiscussions tag.discussions %}
+  {% featuredDiscussions tag.discussions | mapKeys(discussions) %}
 </main>

--- a/src/site/tags/subjects.njk
+++ b/src/site/tags/subjects.njk
@@ -1,7 +1,7 @@
 ---
 layout: default
 pagination:
-  data: collections.taggedContent
+  data: userTags
   resolve: values
   size: 1
   alias: tag

--- a/src/site/tags/subjects.njk
+++ b/src/site/tags/subjects.njk
@@ -9,13 +9,13 @@ permalink: "/tags/{{ tag.name }}/subjects.html"
 renderData:
   title: "Tag: {{ tag.name }}"
   description: "Subjects tagged with #{{ tag.name }} on Science Gossip."
-  ogImage: "{{ tag.subjects[0].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>
   <h2>Subjects</h2>
   <ul class="collection">
-    {% for subject in tag.subjects %}
+    {% for subject in tag.subjects | mapKeys(subjects) %}
       <li class="subject">
         <a href="/subjects/{{ subject.zooniverse_id }}">
           <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>

--- a/src/site/tags/tag.njk
+++ b/src/site/tags/tag.njk
@@ -1,7 +1,7 @@
 ---
 layout: default
 pagination:
-  data: collections.taggedContent
+  data: userTags
   resolve: values
   size: 1
   alias: tag

--- a/src/site/tags/tag.njk
+++ b/src/site/tags/tag.njk
@@ -9,18 +9,18 @@ permalink: "/tags/{{ tag.name }}/"
 renderData:
   title: "Tag: {{ tag.name }}"
   description: "Content tagged with #{{ tag.name }} on Science Gossip."
-  ogImage: "{{ tag.subjects[0].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
 ---
 <main class="page-grid">
   <h1>Tag: {{ tag.name }}</h1>
   <div>
     <h2><a href="/tags/{{ tag.name }}/discussions.html">Discussions</a> ({{ tag.discussions.length }})</h2>
-    {% featuredDiscussions tag.discussions | limit(2) %}
+    {% featuredDiscussions tag.discussions | limit(2) | mapKeys(discussions) %}
   </div>
   <div>
     <h2><a href="/tags/{{ tag.name }}/subjects.html">Subjects</a> ({{ tag.subjects.length }})</h2>
     <ul class="collection">
-      {% for subject in tag.subjects | limit(6) %}
+      {% for subject in tag.subjects | limit(6) | mapKeys(subjects) %}
         <li class="subject">
           <a href="/subjects/{{ subject.zooniverse_id }}">
             <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
@@ -31,7 +31,7 @@ renderData:
 
     <h2><a href="/tags/{{ tag.name }}/collections.html">Collections</a> ({{ tag.userCollections.length }})</h2>
     <ul>
-      {% for collection in tag.userCollections | limit(6) %}
+      {% for collection in tag.userCollections | limit(6) | mapKeys(userCollections) %}
         <li>
           <p><a href="/collections/{{ collection.zooniverse_id }}">{{ collection.zooniverse_id }} {{ collection.title }}</a></p>
           <ul class="collection">


### PR DESCRIPTION
- Add a `userTags` object to the global data for the build (`tags` is reserved in Eleventy.)
- Refactor each tag to use lists of IDs, rather than full objects, to keep the build small.
- Remove the `taggedContent` collection from the Eleventy config.
- Restore collection tags, which were removed when we switched to using files as the data source for `userCollections`.