### PR TITLE
Look up avatars by user.id

### DIFF
--- a/src/boards/_data/users.js
+++ b/src/boards/_data/users.js
@@ -2,5 +2,5 @@ const awaitUsers = require('../../helpers/users');
 
 module.exports = async function () {
   const users = await awaitUsers;
-  return { users };
+  return users;
 }

--- a/src/boards/discussions/discussion.njk
+++ b/src/boards/discussions/discussion.njk
@@ -27,7 +27,7 @@ eleventyComputed:
       <li id={{ comment._id }} class="comment">
         <p>
           <a href="/users/{{ comment.user_name }}">
-            {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+            {% avatar comment.user_name, users[comment.user_id].avatar_url %}
           </a> by
           <a href="/users/{{ comment.user_name }}">
             {{ comment.user_name }}
@@ -64,7 +64,7 @@ eleventyComputed:
     <li id={{ comment._id }} class="comment">
       <p>
         <a href="/users/{{ comment.user_name }}">
-          {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+          {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
         <a href="/users/{{ comment.user_name }}">
@@ -106,7 +106,7 @@ eleventyComputed:
     <li id={{ comment._id }} class="comment">
       <p>
         <a href="/users/{{ comment.user_name }}">
-          {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+          {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
         <a href="/users/{{ comment.user_name }}">

--- a/src/helpers/collections.js
+++ b/src/helpers/collections.js
@@ -33,7 +33,7 @@ async function fetchCollections() {
     collection.tags = [];
     // console.log('Read collection', collection.zooniverse_id);
     userCollections[collection.zooniverse_id] = collection;
-    const owner = users[collection.user_name];
+    const owner = users[collection.user_id];
     const collectionExists = owner && owner.my_collections.find(userCollection => userCollection.zooniverse_id === collection.zooniverse_id);
     if (owner && !collectionExists) {
       owner.my_collections.push(collection);

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -32,14 +32,14 @@ async function fetchUsers() {
 
   for (user of APIusers) {
     if (user.name) {
-      users[user.name] = user;
+      users[user.id] = user;
     }
   }
 
   const { subjects } = await discussionComments;
   for (subjectDiscussion of subjects ) {
     for (comment of subjectDiscussion.comments) {
-      const author = users[comment.user_name];
+      const author = users[comment.user_id];
       const focus = {
         location: subjectDiscussion.focus.location,
         zooniverse_id: subjectDiscussion.focus._id

--- a/src/site/_data/users.js
+++ b/src/site/_data/users.js
@@ -1,0 +1,6 @@
+const awaitUsers = require('../../helpers/users');
+
+module.exports = async function () {
+  const users = await awaitUsers;
+  return users;
+}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -29,7 +29,7 @@ eleventyComputed:
     <li id={{ comment._id }} class="comment">
       <p>
         <a href="/users/{{ comment.user_name }}">
-          {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+          {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
         <a href="/users/{{ comment.user_name }}">

--- a/src/subjects/_data/users.js
+++ b/src/subjects/_data/users.js
@@ -1,0 +1,6 @@
+const awaitUsers = require('../../helpers/users');
+
+module.exports = async function () {
+  const users = await awaitUsers;
+  return users;
+}

--- a/src/subjects/subjects/collections.njk
+++ b/src/subjects/subjects/collections.njk
@@ -25,7 +25,7 @@ eleventyComputed:
     <li id={{ comment._id }} class="comment">
       <p>
         <a href="/users/{{ comment.user_name }}">
-          {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+          {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
         <a href="/users/{{ comment.user_name }}">

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -23,7 +23,7 @@ eleventyComputed:
     <li id={{ comment._id }} class="comment">
       <p>
         <a href="/users/{{ comment.user_name }}">
-          {% avatar comment.user_name, users[comment.user_zooniverse_id].avatar_url %}
+          {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
         <a href="/users/{{ comment.user_name }}">


### PR DESCRIPTION
User name and zooniverse ID both contain characters which make them unreliable as object keys. Key the users object by user.id and look up users by ID.
Add users to board, site and subject builds, where they are used to look up avatars.