### PR TITLE
Use the thumbnail service for subject thumbnails

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,6 +88,7 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addShortcode('avatar', require('./src/components/avatar'));
   eleventyConfig.addShortcode('featuredDiscussions', require('./src/components/featuredDiscussions'));
+  eleventyConfig.addShortcode('subjectImage', require('./src/components/subjectImage'));
   eleventyConfig.addShortcode('tags', require('./src/components/tagList'));
 
   // custom markdown setup

--- a/src/boards/discussions/discussion.njk
+++ b/src/boards/discussions/discussion.njk
@@ -55,7 +55,7 @@ eleventyComputed:
       </a>
     </h2>
     <a href="/subjects/{{ discussion.focus.zooniverse_id }}">
-      {% subjectImage discussion.focus, 'standard' %}
+      {% subjectImage discussion.focus, 'standard', 'subject' %}
     </a>
 
     <h3>Comments</h3>

--- a/src/boards/discussions/discussion.njk
+++ b/src/boards/discussions/discussion.njk
@@ -94,7 +94,7 @@ eleventyComputed:
     {%- for subject in discussion.focus.subjects | limit(4) -%}
       <li id={{ subject.zooniverse_id }} class="subject">
         <a href="/subjects/{{ subject.zooniverse_id }}">
-          <img src={{ subject.location.thumb}}>
+          {% subjectImage subject %}
         </a>
       </li>
     {%- endfor -%}

--- a/src/boards/discussions/discussion.njk
+++ b/src/boards/discussions/discussion.njk
@@ -55,7 +55,7 @@ eleventyComputed:
       </a>
     </h2>
     <a href="/subjects/{{ discussion.focus.zooniverse_id }}">
-      <img alt="Subject {{ discussion.focus.zooniverse_id }}" src={{ discussion.focus.location.standard }}>
+      {% subjectImage discussion.focus, 'standard' %}
     </a>
 
     <h3>Comments</h3>
@@ -94,7 +94,7 @@ eleventyComputed:
     {%- for subject in discussion.focus.subjects | limit(4) -%}
       <li id={{ subject.zooniverse_id }} class="subject">
         <a href="/subjects/{{ subject.zooniverse_id }}">
-          {% subjectImage subject %}
+          {% subjectImage subject, 'thumb' %}
         </a>
       </li>
     {%- endfor -%}

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -1,4 +1,4 @@
-module.exports = function subjectImage(subject, size='standard') {
+module.exports = function subjectImage(subject, size='standard', className) {
   try {
     let url = subject.location.standard.replace('http://', 'https://');
     const passThrough = (size === 'standard') || url.endsWith('.png');
@@ -6,7 +6,8 @@ module.exports = function subjectImage(subject, size='standard') {
     const staticRoot = 'zooniverse-static.s3.amazonaws.com/';
     const thumbnailPath = url.replace('https://', '');
     const src =  passThrough ? url : `https://thumbnails.zooniverse.org/150x150/${thumbnailPath.replace(staticRoot, '')}`;
-    return `<img loading=lazy alt="Subject ${zooniverseID}" src=${src}>`;
+    const classAttr = className ? `class=${className}` : '';
+    return `<img ${classAttr} loading=lazy alt="Subject ${zooniverseID}" src=${src}>`;
   } catch (e) {
     console.log(e.message);
     console.log(subject);

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -1,8 +1,7 @@
-module.exports = function subjectImage(subject) {
+module.exports = function subjectImage(subject, size='standard') {
   try {
-    let url = subject.location.standard;
-    const passThrough = url.endsWith('.png');
-    url = url.replace('http://', 'https://');
+    let url = subject.location.standard.replace('http://', 'https://');
+    const passThrough = (size === 'standard') || url.endsWith('.png');
     const zooniverseID = subject.zooniverse_id || subject._id;
     const staticRoot = 'zooniverse-static.s3.amazonaws.com/';
     const thumbnailPath = url.replace('https://', '');

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -1,0 +1,16 @@
+module.exports = function subjectImage(subject) {
+  try {
+    let url = subject.location.standard;
+    const passThrough = url.endsWith('.png');
+    url = url.replace('http://', 'https://');
+    const zooniverseID = subject.zooniverse_id || subject._id;
+    const staticRoot = 'zooniverse-static.s3.amazonaws.com/';
+    const thumbnailPath = url.replace('https://', '');
+    const src =  passThrough ? url : `https://thumbnails.zooniverse.org/150x150/${thumbnailPath.replace(staticRoot, '')}`;
+    return `<img loading=lazy alt="Subject ${zooniverseID}" src=${src}>`;
+  } catch (e) {
+    console.log(e.message);
+    console.log(subject);
+    return '';
+  }
+}

--- a/src/site/recent/index.njk
+++ b/src/site/recent/index.njk
@@ -19,7 +19,7 @@ eleventyComputed:
     {%- for subject in recents.subjects -%}
       <li>
         <a href="/subjects/{{ subject.focus._id }}">
-          {% subjectImage subject.focus %}
+          {% subjectImage subject.focus, 'thumb' %}
         </a>
         <p>
           {%- markdown -%}
@@ -66,7 +66,7 @@ eleventyComputed:
             {%- for subject in collection.focus.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ subject.zooniverse_id }}">
-                  {% subjectImage subject %}
+                  {% subjectImage subject, 'thumb' %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/site/recent/index.njk
+++ b/src/site/recent/index.njk
@@ -19,7 +19,7 @@ eleventyComputed:
     {%- for subject in recents.subjects -%}
       <li>
         <a href="/subjects/{{ subject.focus._id }}">
-          <img alt="Subject {{ subject.focus._id }}" src={{ subject.focus.location.thumb}}>
+          {% subjectImage subject.focus %}
         </a>
         <p>
           {%- markdown -%}
@@ -66,7 +66,7 @@ eleventyComputed:
             {%- for subject in collection.focus.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ subject.zooniverse_id }}">
-                  <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+                  {% subjectImage subject %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -10,7 +10,7 @@ permalink: "/collections/{{ userCollection.zooniverse_id}}/"
 eleventyComputed:
   title: "{{ userCollection.title }}"
   description: "{{ userCollection.description }}"
-  ogImage: "{{ userCollection.subjects[0].location.thumb }}"
+  ogImage: "{{ userCollection.subjects[0].location.standard }}"
 ---
 <main class="page-grid">
   <div>
@@ -68,7 +68,7 @@ eleventyComputed:
   {%- for subject in userCollection.subjects -%}
     <li class="subject">
       <a href="/subjects/{{ subject.zooniverse_id }}">
-        <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+        {% subjectImage subject %}
       </a> 
     </li>
   {%- endfor -%}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -68,7 +68,7 @@ eleventyComputed:
   {%- for subject in userCollection.subjects -%}
     <li class="subject">
       <a href="/subjects/{{ subject.zooniverse_id }}">
-        {% subjectImage subject %}
+        {% subjectImage subject, 'thumb' %}
       </a> 
     </li>
   {%- endfor -%}

--- a/src/site/userTags/collections.njk
+++ b/src/site/userTags/collections.njk
@@ -10,7 +10,7 @@ permalink: "/tags/{{ tag.name }}/collections.html"
 eleventyComputed:
   title: "Tag: {{ tag.name }}"
   description: "Collections tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>
@@ -23,7 +23,7 @@ eleventyComputed:
           {%- for collectionSubject in collection.subjects | limit(4) -%}
             <li class="subject">
               <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                <img alt="Subject {{ collectionSubject.zooniverse_id }}" src={{ collectionSubject.location.thumb}}>
+                {% subjectImage collectionSubject %}
               </a>
             </li>
           {%- endfor -%}

--- a/src/site/userTags/collections.njk
+++ b/src/site/userTags/collections.njk
@@ -23,7 +23,7 @@ eleventyComputed:
           {%- for collectionSubject in collection.subjects | limit(4) -%}
             <li class="subject">
               <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                {% subjectImage collectionSubject %}
+                {% subjectImage collectionSubject, 'thumb' %}
               </a>
             </li>
           {%- endfor -%}

--- a/src/site/userTags/discussions.njk
+++ b/src/site/userTags/discussions.njk
@@ -10,7 +10,7 @@ permalink: "/tags/{{ tag.name }}/discussions.html"
 eleventyComputed:
   title: "Tag: {{ tag.name }}"
   description: "Discussions tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>

--- a/src/site/userTags/subjects.njk
+++ b/src/site/userTags/subjects.njk
@@ -10,7 +10,7 @@ permalink: "/tags/{{ tag.name }}/subjects.html"
 eleventyComputed:
   title: "Tag: {{ tag.name }}"
   description: "Subjects tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>
@@ -19,7 +19,7 @@ eleventyComputed:
     {% for subject in tag.subjects | mapKeys(subjects) %}
       <li class="subject">
         <a href="/subjects/{{ subject.zooniverse_id }}">
-          <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+          {% subjectImage subject %}
         </a> 
       </li>
     {% endfor %}

--- a/src/site/userTags/subjects.njk
+++ b/src/site/userTags/subjects.njk
@@ -19,7 +19,7 @@ eleventyComputed:
     {% for subject in tag.subjects | mapKeys(subjects) %}
       <li class="subject">
         <a href="/subjects/{{ subject.zooniverse_id }}">
-          {% subjectImage subject %}
+          {% subjectImage subject, 'thumb' %}
         </a> 
       </li>
     {% endfor %}

--- a/src/site/userTags/tag.njk
+++ b/src/site/userTags/tag.njk
@@ -24,7 +24,7 @@ eleventyComputed:
       {% for subject in tag.subjects | limit(6) | mapKeys(subjects) %}
         <li class="subject">
           <a href="/subjects/{{ subject.zooniverse_id }}">
-            {% subjectImage subject %}
+            {% subjectImage subject, 'thumb' %}
           </a> 
         </li>
       {% endfor %}
@@ -39,7 +39,7 @@ eleventyComputed:
             {%- for collectionSubject in collection.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                  {% subjectImage collectionSubject %}
+                  {% subjectImage collectionSubject, 'thumb' %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/site/userTags/tag.njk
+++ b/src/site/userTags/tag.njk
@@ -10,7 +10,7 @@ permalink: "/tags/{{ tag.name }}/"
 eleventyComputed:
   title: "Tag: {{ tag.name }}"
   description: "Content tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.thumb }}"
+  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main class="page-grid">
   <h1>Tag: {{ tag.name }}</h1>
@@ -24,7 +24,7 @@ eleventyComputed:
       {% for subject in tag.subjects | limit(6) | mapKeys(subjects) %}
         <li class="subject">
           <a href="/subjects/{{ subject.zooniverse_id }}">
-            <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+            {% subjectImage subject %}
           </a> 
         </li>
       {% endfor %}
@@ -39,7 +39,7 @@ eleventyComputed:
             {%- for collectionSubject in collection.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                  <img alt="Subject {{ collectionSubject.zooniverse_id }}" src={{ collectionSubject.location.thumb}}>
+                  {% subjectImage collectionSubject %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/site/users/collections.njk
+++ b/src/site/users/collections.njk
@@ -21,7 +21,7 @@ eleventyComputed:
         {%- for subject in collection.subjects | limit(4) -%}
           <li class="subject">
             <a href="/subjects/{{ subject.zooniverse_id }}">
-              {% subjectImage subject %}
+              {% subjectImage subject, 'thumb' %}
             </a>
           </li>
         {%- endfor -%}

--- a/src/site/users/collections.njk
+++ b/src/site/users/collections.njk
@@ -21,7 +21,7 @@ eleventyComputed:
         {%- for subject in collection.subjects | limit(4) -%}
           <li class="subject">
             <a href="/subjects/{{ subject.zooniverse_id }}">
-              <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+              {% subjectImage subject %}
             </a>
           </li>
         {%- endfor -%}

--- a/src/site/users/comments.njk
+++ b/src/site/users/comments.njk
@@ -10,7 +10,7 @@ permalink: "/users/{{ user.name }}/comments.html"
 eleventyComputed:
   title: "Profile: {{ user.name }}: comments"
   description: "Subject comments by {{ user.name }} on {{ project.display_name }}."
-  ogImage: "{{ user.subjects[0].focus.location.thumb }}"
+  ogImage: "{{ user.subjects[0].focus.location.standard }}"
 ---
 <main>
   <h1><a href="/users/{{ user.name }}">Profile: {{ user.name }}</a></h1>
@@ -19,7 +19,7 @@ eleventyComputed:
   {%- for subject in user.subjects -%}
     <li id={{ subject.focus.zooniverse_id }}>
       <a href="/subjects/{{ subject.focus.zooniverse_id }}">
-        <img alt="Subject {{ subject.focus.zooniverse_id }}" src={{ subject.focus.location.thumb}}>
+        {% subjectImage subject.focus %}
       </a>
       <p>
         {%- markdown -%}

--- a/src/site/users/comments.njk
+++ b/src/site/users/comments.njk
@@ -19,7 +19,7 @@ eleventyComputed:
   {%- for subject in user.subjects -%}
     <li id={{ subject.focus.zooniverse_id }}>
       <a href="/subjects/{{ subject.focus.zooniverse_id }}">
-        {% subjectImage subject.focus %}
+        {% subjectImage subject.focus, 'thumb' %}
       </a>
       <p>
         {%- markdown -%}

--- a/src/site/users/user.njk
+++ b/src/site/users/user.njk
@@ -37,7 +37,7 @@ eleventyComputed:
     {%- for subject in user.subjects | limit(5) -%}
       <li id={{ subject.focus.zooniverse_id }}>
         <a href="/subjects/{{ subject.focus.zooniverse_id }}">
-          {% subjectImage subject.focus %}
+          {% subjectImage subject.focus, 'thumb' %}
         </a>
         <p>
           {%- markdown -%}
@@ -58,7 +58,7 @@ eleventyComputed:
           {%- for subject in collection.subjects | limit(4) -%}
             <li class="subject">
               <a href="/subjects/{{ subject.zooniverse_id }}">
-                {% subjectImage subject %}
+                {% subjectImage subject, 'thumb' %}
               </a>
             </li>
           {%- endfor -%}

--- a/src/site/users/user.njk
+++ b/src/site/users/user.njk
@@ -37,7 +37,7 @@ eleventyComputed:
     {%- for subject in user.subjects | limit(5) -%}
       <li id={{ subject.focus.zooniverse_id }}>
         <a href="/subjects/{{ subject.focus.zooniverse_id }}">
-          <img alt="Subject {{ subject.focus.zooniverse_id }}" src={{ subject.focus.location.thumb}}>
+          {% subjectImage subject.focus %}
         </a>
         <p>
           {%- markdown -%}
@@ -58,7 +58,7 @@ eleventyComputed:
           {%- for subject in collection.subjects | limit(4) -%}
             <li class="subject">
               <a href="/subjects/{{ subject.zooniverse_id }}">
-                <img alt="Subject {{ subject.zooniverse_id }}" src={{ subject.location.thumb}}>
+                {% subjectImage subject %}
               </a>
             </li>
           {%- endfor -%}

--- a/src/subjects/subjects/collections.njk
+++ b/src/subjects/subjects/collections.njk
@@ -18,7 +18,7 @@ eleventyComputed:
       <a href="/subjects/{{ subject.zooniverse_id }}">Subject: {{ subject.zooniverse_id }}</a>
     </h1>
 
-    {% subjectImage subject, 'standard' %}
+    {% subjectImage subject, 'standard', 'subject' %}
 
     <h2>Comments</h2>
     <ul>

--- a/src/subjects/subjects/collections.njk
+++ b/src/subjects/subjects/collections.njk
@@ -17,7 +17,8 @@ eleventyComputed:
     <h1>
       <a href="/subjects/{{ subject.zooniverse_id }}">Subject: {{ subject.zooniverse_id }}</a>
     </h1>
-    <img class="subject" src={{ subject.location.standard }} >
+
+    {% subjectImage subject, 'standard' %}
 
     <h2>Comments</h2>
     <ul>
@@ -56,7 +57,7 @@ eleventyComputed:
             {%- for collectionSubject in collection.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                  {% subjectImage collectionSubject %}
+                  {% subjectImage collectionSubject, 'thumb' %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/subjects/subjects/collections.njk
+++ b/src/subjects/subjects/collections.njk
@@ -10,7 +10,7 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/collections.html"
 eleventyComputed:
   title: "Subject {{ subject.zooniverse_id }}: Collections"
   description: "Collections that include subject {{ subject.zooniverse_id }} from {{ project.display_name }}."
-  ogImage: "{{ subject.location.thumb }}"
+  ogImage: "{{ subject.location.standard }}"
 ---
 <div class="page-grid">
   <aside class=" focus">
@@ -56,7 +56,7 @@ eleventyComputed:
             {%- for collectionSubject in collection.subjects | limit(4) -%}
               <li class="subject">
                 <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                  <img alt="Subject {{ collectionSubject.zooniverse_id }}" src={{ collectionSubject.location.thumb}}>
+                  {% subjectImage collectionSubject %}
                 </a>
               </li>
             {%- endfor -%}

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -10,7 +10,7 @@ permalink: "/subjects/{{ subject.zooniverse_id }}/"
 eleventyComputed:
   title: "Subject {{ subject.zooniverse_id }}"
   description: "Subject {{ subject.zooniverse_id }} from {{ project.display_name }}."
-  ogImage: "{{ subject.location.thumb }}"
+  ogImage: "{{ subject.location.standard }}"
 ---
 <div class="page-grid subject-page-grid">
   <main class="focus">
@@ -64,7 +64,7 @@ eleventyComputed:
                 {%- for collectionSubject in collection.subjects | limit(3) -%}
                   <li class="subject">
                     <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                      <img alt="Subject {{ collectionSubject.zooniverse_id }}" src={{ collectionSubject.location.thumb}}>
+                      {% subjectImage collectionSubject %}
                     </a>
                   </li>
                 {%- endfor -%}

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -16,7 +16,7 @@ eleventyComputed:
   <main class="focus">
     <h1>Subject: {{ subject.zooniverse_id }}</h1>
 
-    {% subjectImage subject, 'standard' %}
+    {% subjectImage subject, 'standard', 'subject' %}
 
     <h2>Comments</h2>
     <ul>

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -15,7 +15,8 @@ eleventyComputed:
 <div class="page-grid subject-page-grid">
   <main class="focus">
     <h1>Subject: {{ subject.zooniverse_id }}</h1>
-    <img class="subject" alt="{{ subject.zooniverse_id }}" src={{ subject.location.standard }} >
+
+    {% subjectImage subject, 'standard' %}
 
     <h2>Comments</h2>
     <ul>
@@ -64,7 +65,7 @@ eleventyComputed:
                 {%- for collectionSubject in collection.subjects | limit(3) -%}
                   <li class="subject">
                     <a href="/subjects/{{ collectionSubject.zooniverse_id }}">
-                      {% subjectImage collectionSubject %}
+                      {% subjectImage collectionSubject, 'thumb' %}
                     </a>
                   </li>
                 {%- endfor -%}


### PR DESCRIPTION
Add a `subjectImage` shortcode that can generate a thumbnail via our thumbnail service.
Replace all subject thumbnail images with the shortcode.
Replace thumbnails with the standard image in OpenGraph metadata.
Replaces `http://` with `https://` for all subject URLs.

Closes #18.