### PR TITLE
Remove local template data

### DIFF
--- a/src/boards/_data/boards.js
+++ b/src/boards/_data/boards.js
@@ -4,5 +4,5 @@ const store = require('../../helpers/store');
 module.exports = async function () {
   console.log('building boards');
   const boards = await awaitBoards;
-  return { boards };
+  return boards;
 }

--- a/src/boards/_data/discussions.js
+++ b/src/boards/_data/discussions.js
@@ -5,5 +5,5 @@ module.exports = async function fetchDiscussions() {
   console.log('building discussions');
   await awaitBoards;
   const { discussions } = store;
-  return { discussions };
+  return discussions;
 }

--- a/src/boards/boards/boards.11tydata.js
+++ b/src/boards/boards/boards.11tydata.js
@@ -1,9 +1,0 @@
-const awaitBoards = require('../../helpers/boards');
-const store = require('../../helpers/store');
-
-module.exports = async function () {
-  console.log('building boards');
-  const boards = await awaitBoards;
-  const { discussions } = store;
-  return { boards, discussions };
-}

--- a/src/site/_data/subjects.js
+++ b/src/site/_data/subjects.js
@@ -1,0 +1,6 @@
+const awaitSubjects = require('../../helpers/subjects');
+
+module.exports = async function() {
+  const subjects = await awaitSubjects;
+  return subjects;
+}

--- a/src/site/_data/userCollections.js
+++ b/src/site/_data/userCollections.js
@@ -2,5 +2,5 @@ const awaitCollections = require('../../helpers/collections');
 
 module.exports = async function () {
   const userCollections = await awaitCollections;
-  return { userCollections };
+  return userCollections;
 }

--- a/src/site/_data/userTags.js
+++ b/src/site/_data/userTags.js
@@ -1,0 +1,6 @@
+const awaitTags = require('../../helpers/tags');
+
+module.exports = async function() {
+  const userTags = await awaitTags;
+  return userTags;
+}

--- a/src/site/userTags/userTags.11tydata.js
+++ b/src/site/userTags/userTags.11tydata.js
@@ -1,9 +1,0 @@
-const awaitCollections = require('../../helpers/collections');
-const awaitSubjects = require('../../helpers/subjects');
-const awaitTags = require('../../helpers/tags');
-
-module.exports = async function() {
-  const userTags = await awaitTags;
-  const [ userCollections, subjects ] = await Promise.all([awaitCollections, awaitSubjects]);
-  return { subjects, userCollections, userTags };
-}


### PR DESCRIPTION
Template data files run once for each page in a paginated collection. We only want them to run once, to generate the initial collections (subjects, tags, discussions etc.) This moves them back into global data files for each build.