### PR TITLE
Sanitise usernames

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -105,11 +105,7 @@ module.exports = function(eleventyConfig) {
     linkify: true
   };
 
-  const slugify = require('slugify');
-
-  function slug(string) {
-    return slugify(string, { lower: true });
-  }
+  const slug = require('./src/helpers/slug');
 
   const mentionUsers = {
     name: 'mentionUsers',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,6 +88,7 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.addShortcode('avatar', require('./src/components/avatar'));
   eleventyConfig.addShortcode('collectionSummary', require('./src/components/collectionSummary'));
+  eleventyConfig.addShortcode('discussionSummary', require('./src/components/discussionSummary'));
   eleventyConfig.addShortcode('featuredDiscussions', require('./src/components/featuredDiscussions'));
   eleventyConfig.addAsyncShortcode('pageHeader', require('./src/components/pageHeader'));
   eleventyConfig.addAsyncShortcode('pageMetadata', require('./src/components/pageMetadata'));
@@ -103,12 +104,13 @@ module.exports = function(eleventyConfig) {
     breaks: true,
     linkify: true
   };
+  const slug = require('./src/helpers/slug');
 
   const mentionUsers = {
     name: 'mentionUsers',
     regex: /@(\w+)\b/,
     replace: (match) => {
-      const url = `/users/${match}`;
+      const url = `/users/${slug(match)}`;
       return `<a href="${url}">@${match}</a>`;
     }
   }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -104,7 +104,12 @@ module.exports = function(eleventyConfig) {
     breaks: true,
     linkify: true
   };
-  const slug = require('./src/helpers/slug');
+
+  const slugify = require('slugify');
+
+  function slug(string) {
+    return slugify(string, { lower: true });
+  }
 
   const mentionUsers = {
     name: 'mentionUsers',

--- a/src/api/templates/user.njk
+++ b/src/api/templates/user.njk
@@ -5,6 +5,6 @@ pagination:
   resolve: values
   size: 1
   alias: user
-permalink: "/api/users/{{ user.name }}.json"
+permalink: "/api/users/{{ user.name | slug }}.json"
 ---
 {{ user | dump | safe }}

--- a/src/boards/boards/chat.njk
+++ b/src/boards/boards/chat.njk
@@ -21,19 +21,13 @@ eleventyComputed:
     <ul class="discussion-list">
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p class="pinned-discussion">
-          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
-        </p>
-        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
-        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+         {% discussionSummary discussion=discussion, className='pinned-discussion' %}
       </li>
     {% endfor %}
 
     {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
       <li>
-        <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-        <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-        <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+        {% discussionSummary discussion=discussions[discussionID] %}
       </li>
     {%- endfor -%}
     </ul>

--- a/src/boards/boards/help.njk
+++ b/src/boards/boards/help.njk
@@ -21,19 +21,13 @@ eleventyComputed:
     <ul class="discussion-list">
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p class="pinned-discussion">
-          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
-        </p>
-        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
-        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+         {% discussionSummary discussion=discussion, className='pinned-discussion' %}
       </li>
     {% endfor %}
 
     {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
       <li>
-        <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-        <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-        <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+        {% discussionSummary discussion=discussions[discussionID] %}
       </li>
     {%- endfor -%}
     </ul>

--- a/src/boards/boards/science.njk
+++ b/src/boards/boards/science.njk
@@ -21,19 +21,13 @@ eleventyComputed:
     <ul class="discussion-list">
     {% for discussion in board.featured | pinned(board.zooniverse_id) %}
       <li>
-        <p class="pinned-discussion">
-          <a href="./discussions/{{ discussion.zooniverse_id }}">{{ discussion.title }}</a>
-        </p>
-        <p>{{ discussion.comments }} posts / {{ discussion.users }} participants</p>
-        <p>Last post {{ discussion.last_comment.created_at | date }} by {{ discussion.last_comment.user_name }}</p>
+        {% discussionSummary discussion=discussion, className='pinned-discussion' %}
       </li>
     {% endfor %}
 
     {%- for discussionID in board.links.discussions | notFeatured(board.featured) -%}
       <li>
-        <p><a href="./discussions/{{ discussions[discussionID].zooniverse_id }}">{{ discussions[discussionID].title }}</a></p>
-        <p>{{ discussions[discussionID].comments.length }} posts / {{ discussions[discussionID].users }} participants</p>
-        <p>Last post {{ discussions[discussionID].last_comment.created_at | date }} by {{ discussions[discussionID].last_comment.user_name }}</p>
+        {% discussionSummary discussion=discussions[discussionID] %}
       </li>
     {%- endfor -%}
     </ul>

--- a/src/boards/discussions/discussion.njk
+++ b/src/boards/discussions/discussion.njk
@@ -26,10 +26,10 @@ eleventyComputed:
     {%- for comment in discussion.comments -%}
       <li id={{ comment._id }} class="comment">
         <p>
-          <a href="/users/{{ comment.user_name }}">
+          <a href="/users/{{ comment.user_name | slug }}">
             {% avatar comment.user_name, users[comment.user_id].avatar_url %}
           </a> by
-          <a href="/users/{{ comment.user_name }}">
+          <a href="/users/{{ comment.user_name | slug }}">
             {{ comment.user_name }}
           </a>
           {% if comment.response_to %}
@@ -63,11 +63,11 @@ eleventyComputed:
     {%- for comment in discussion.focus.discussion.comments | reverse -%}
     <li id={{ comment._id }} class="comment">
       <p>
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {{ comment.user_name }}
         </a>
         {% if comment.response_to %}
@@ -105,11 +105,11 @@ eleventyComputed:
     {%- for comment in discussion.focus.discussion.comments | reverse -%}
     <li id={{ comment._id }} class="comment">
       <p>
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {{ comment.user_name }}
         </a>
         {% if comment.response_to %}

--- a/src/components/discussionSummary.js
+++ b/src/components/discussionSummary.js
@@ -1,0 +1,37 @@
+const moment = require('moment');
+const slug = require('../helpers/slug');
+
+function authorCount(discussion, className) {
+  if (discussion.users) {
+    return discussion.users;
+  }
+
+  const authors = {};
+  for (comment of discussion.comments) {
+    authors[comment.user_name] = null;
+  }
+  return Object.keys(authors).length;
+}
+
+module.exports = function discussionSummary({ discussion, className }) {
+  const lastPost = moment(discussion.last_comment.created_at).format('LLL');
+  const posts = discussion.comments.length || discussion.comments;
+  const classAttr = className ? `class="${className}"` : '';
+  return `
+    <p ${classAttr}>
+      <a href="/boards/${ discussion.board._id }/discussions/${ discussion.zooniverse_id }">
+        ${ discussion.title }
+      </a>
+    </p>
+    <p>${ posts } posts / ${ authorCount(discussion) } participants</p>
+    <p>
+      Last post
+      <time datetime="${discussion.last_comment.created_at}">${ lastPost }</time>
+      by
+      <a href="/users/${slug(discussion.last_comment.user_name)}">
+        ${ discussion.last_comment.user_name }
+      </a>
+    </p>
+  </p>
+  `
+}

--- a/src/components/featuredDiscussions.js
+++ b/src/components/featuredDiscussions.js
@@ -1,4 +1,9 @@
 const moment = require('moment');
+const slugify = require('slugify');
+
+function slug(string) {
+  return slugify(string, { lower: true });
+}
 
 function authorCount(discussion) {
   if (discussion.users) {
@@ -26,7 +31,7 @@ function discussionSummary(discussion) {
       Last post
       <time datetime="${discussion.last_comment.created_at}">${ lastPost }</time>
       by
-      <a href="/users/${discussion.last_comment.user_name}">
+      <a href="/users/${slug(discussion.last_comment.user_name)}">
         ${ discussion.last_comment.user_name }
       </a>
     </p>

--- a/src/components/featuredDiscussions.js
+++ b/src/components/featuredDiscussions.js
@@ -1,9 +1,5 @@
 const moment = require('moment');
-const slugify = require('slugify');
-
-function slug(string) {
-  return slugify(string, { lower: true });
-}
+const slug = require('../helpers/slug');
 
 function authorCount(discussion) {
   if (discussion.users) {

--- a/src/components/featuredDiscussions.js
+++ b/src/components/featuredDiscussions.js
@@ -1,44 +1,9 @@
-const moment = require('moment');
-const slug = require('../helpers/slug');
-
-function authorCount(discussion) {
-  if (discussion.users) {
-    return discussion.users;
-  }
-
-  const authors = {};
-  for (comment of discussion.comments) {
-    authors[comment.user_name] = null;
-  }
-  return Object.keys(authors).length;
-}
-
-function discussionSummary(discussion) {
-  const lastPost = moment(discussion.last_comment.created_at).format('LLL');
-  const posts = discussion.comments.length || discussion.comments;
-  return `
-    <p>
-      <a href="/boards/${ discussion.board._id }/discussions/${ discussion.zooniverse_id }">
-        ${ discussion.title }
-      </a>
-    </p>
-    <p>${ posts } posts / ${ authorCount(discussion) } participants</p>
-    <p>
-      Last post
-      <time datetime="${discussion.last_comment.created_at}">${ lastPost }</time>
-      by
-      <a href="/users/${slug(discussion.last_comment.user_name)}">
-        ${ discussion.last_comment.user_name }
-      </a>
-    </p>
-  </p>
-  `
-}
+const discussionSummary = require('./discussionSummary');
 
 function listItem(discussion) {
   return `
     <li class="discussion-preview">
-      ${discussionSummary(discussion)}
+      ${discussionSummary({ discussion })}
     </li>
   `
 }

--- a/src/helpers/slug.js
+++ b/src/helpers/slug.js
@@ -1,0 +1,7 @@
+const slugify = require('slugify');
+
+function slug(string) {
+  return slugify(string, { lower: true });
+}
+
+module.exports = slug;

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -32,6 +32,9 @@ async function fetchUsers() {
 
   for (user of APIusers) {
     if (user.name) {
+      // remove the domain from email addresses in usernames.
+      user.name = user.name.split('@');
+      user.name = user.name[0];
       users[user.id] = user;
     }
   }

--- a/src/site/recent/index.njk
+++ b/src/site/recent/index.njk
@@ -29,7 +29,7 @@ eleventyComputed:
         <p>
           <time datetime="{{ subject.comment.created_at }}">{{ subject.comment.created_at | date }}</time>
           by
-          <a href="/users/{{ subject.comment.user_name }}">{{ subject.comment.user_name }}</a>
+          <a href="/users/{{ subject.comment.user_name | slug }}">{{ subject.comment.user_name }}</a>
         </p>
       </li>
     {%- endfor -%}
@@ -50,7 +50,7 @@ eleventyComputed:
             <p>
               <time datetime="{{ discussion.comment.created_at }}">{{ discussion.comment.created_at | date }}</time>
               by
-              <a href="/users/{{ discussion.comment.user_name }}">{{ discussion.comment.user_name }}</a>
+              <a href="/users/{{ discussion.comment.user_name | slug }}">{{ discussion.comment.user_name }}</a>
             </p>
           </li>
         {% endfor  %}
@@ -70,7 +70,7 @@ eleventyComputed:
           <p>
             <time datetime="{{ collection.comment.created_at }}">{{ collection.comment.created_at | date }}</time>
             by
-            <a href="/users/{{ collection.comment.user_name }}">{{ collection.comment.user_name }}</a>
+            <a href="/users/{{ collection.comment.user_name | slug }}">{{ collection.comment.user_name }}</a>
           </p>
         </li>
       {%- endfor -%}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -29,11 +29,11 @@ eleventyComputed:
     {%- for comment in userCollection.discussion.comments | reverse -%}
     <li id={{ comment._id }} class="comment">
       <p>
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {{ comment.user_name }}
         </a>
         {% if comment.response_to %}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -15,7 +15,7 @@ eleventyComputed:
 <main class="page-grid">
   <div>
     <h1 class="mb-0">Collection: {{ userCollection.title }}</h1>
-    <p class="mb-2">by <a href="/users/{{ userCollection.user_name }}">{{ userCollection.user_name }}</a></p>
+    <p class="mb-2">by <a href="/users/{{ userCollection.user_name | slug }}">{{ userCollection.user_name }}</a></p>
     <p class="mb-4">{{ userCollection.description }}</p>
     <h2>Tags</h2>
     <ul class="tag-list">

--- a/src/site/users/collections.njk
+++ b/src/site/users/collections.njk
@@ -6,12 +6,12 @@ pagination:
   resolve: values
   size: 1
   alias: user
-permalink: "/users/{{ user.name }}/collections.html"
+permalink: "/users/{{ user.name | slug }}/collections.html"
 eleventyComputed:
   title: "Profile: {{ user.name }}: collections"
 ---
 <main>
-  <h1><a href="/users/{{ user.name }}">Profile: {{ user.name }}</a></h1>
+  <h1><a href="/users/{{ user.name | slug }}">Profile: {{ user.name }}</a></h1>
   <h2>Collections ({{ user.my_collections.length }})</h2>
   <ul>
   {%- for collection in user.my_collections -%}

--- a/src/site/users/comments.njk
+++ b/src/site/users/comments.njk
@@ -6,14 +6,14 @@ pagination:
   resolve: values
   size: 1
   alias: user
-permalink: "/users/{{ user.name }}/comments.html"
+permalink: "/users/{{ user.name | slug }}/comments.html"
 eleventyComputed:
   title: "Profile: {{ user.name }}: comments"
   description: "Subject comments by {{ user.name }} on {{ project.display_name }}."
   ogImage: "{{ user.subjects[0].focus.location.standard }}"
 ---
 <main>
-  <h1><a href="/users/{{ user.name }}">Profile: {{ user.name }}</a></h1>
+  <h1><a href="/users/{{ user.name | slug }}">Profile: {{ user.name }}</a></h1>
   <h2>Subject comments ({{ user.subjects.length }})</h2>
   <ul class="comments-list">
   {%- for subject in user.subjects -%}

--- a/src/site/users/user.njk
+++ b/src/site/users/user.njk
@@ -6,7 +6,7 @@ pagination:
   resolve: values
   size: 1
   alias: user
-permalink: "/users/{{ user.name }}/"
+permalink: "/users/{{ user.name | slug }}/"
 eleventyComputed:
   title: "Profile: {{ user.name }}"
 ---

--- a/src/subjects/subjects/collections.njk
+++ b/src/subjects/subjects/collections.njk
@@ -25,11 +25,11 @@ eleventyComputed:
     {%- for comment in subject.discussion.comments | reverse -%}
     <li id={{ comment._id }} class="comment">
       <p>
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {{ comment.user_name }}
         </a>
         {% if comment.response_to %}

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -23,11 +23,11 @@ eleventyComputed:
     {%- for comment in subject.discussion.comments | reverse -%}
     <li id={{ comment._id }} class="comment">
       <p>
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {% avatar comment.user_name, users[comment.user_id].avatar_url %}
         </a>
         by
-        <a href="/users/{{ comment.user_name }}">
+        <a href="/users/{{ comment.user_name | slug }}">
           {{ comment.user_name }}
         </a>
         {% if comment.response_to %}


### PR DESCRIPTION
Hide email addresses by splitting usernames on `@` and keeping the first part.

Slugify usernames in URLs and links with the `slug` filter in templates. Add a `slug` function to custom shortcodes to also slugify @-mentions and author links in the featured discussion lists.

I've also tidied up discussion summaries by moving them into a shared function.

Examples of usernames from Penguin Watch:
https://talk.penguinwatch.org/users/less*(((-greater-less/
https://talk.penguinwatch.org/users/4bellabee707/

Closes #38.