### PR TITLE
Configure the project domain

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -89,6 +89,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addShortcode('avatar', require('./src/components/avatar'));
   eleventyConfig.addShortcode('collectionSummary', require('./src/components/collectionSummary'));
   eleventyConfig.addShortcode('featuredDiscussions', require('./src/components/featuredDiscussions'));
+  eleventyConfig.addAsyncShortcode('pageMetadata', require('./src/components/pageMetadata'));
   eleventyConfig.addShortcode('subjectImage', require('./src/components/subjectImage'));
   eleventyConfig.addShortcode('tags', require('./src/components/tagList'));
 

--- a/src/boards/_includes/layouts/default.njk
+++ b/src/boards/_includes/layouts/default.njk
@@ -1,33 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="{{ project.display_name }} Talk" />
-    <meta property='og:url' content="https://talk.sciencegossip.org{{ page.url }}" />
-    <meta property='og:title' content="{{ title }}" />
-
-    {% if description %}
-    <meta name="description" content="{{ description }}" />
-    <meta name='twitter:description' content="{{ description }}" />
-    <meta property='og:description' content="{{ description }}" />
-    {% endif %}
-
-    {% if ogImage %}
-    <meta property='og:image' content="{{ ogImage }}" />
-    <meta name='twitter:image' content="{{ ogImage }}" />
-    {% endif %}
-
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@the_zooniverse" />
-    <meta name="twitter:site" content="@the_zooniverse" />
-
-    <link rel="icon" href="/img/favicon.ico">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,700">
+    {% pageMetadata page, title, description, ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
-    <title>{{ title }}</title>
   </head>
   <body>
     <header>

--- a/src/boards/_includes/layouts/default.njk
+++ b/src/boards/_includes/layouts/default.njk
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    {% pageMetadata page, title, description, ogImage %}
+    {% pageMetadata page=page, title=title, description=description, ogImage=ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
   </head>
   <body>

--- a/src/components/pageMetadata.js
+++ b/src/components/pageMetadata.js
@@ -1,0 +1,41 @@
+const awaitProject = require('../helpers/project');
+
+function metaDesc(description) {
+  return `
+    <meta name="description" content="${ description }" />
+    <meta name='twitter:description' content="${ description }" />
+    <meta property='og:description' content="${ description }" />
+  `;
+}
+
+function metaImage(ogImage) {
+  return `
+    <meta property='og:image' content="${ ogImage }" />
+    <meta name='twitter:image' content="${ ogImage }" />
+  `;
+}
+
+module.exports = async function(page, title, description, ogImage){
+  const project = await awaitProject;
+  return `
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="${ project.display_name } Talk" />
+    <meta property='og:url' content="https://talk.sciencegossip.org${ page.url }" />
+    <meta property='og:title' content="${ title }" />
+
+    ${ description ? metaDesc(description) : ''}
+
+    ${ ogImage ? metaImage(ogImage) : ''}
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:creator" content="@the_zooniverse" />
+    <meta name="twitter:site" content="@the_zooniverse" />
+
+    <link rel="icon" href="/img/favicon.ico">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,700">
+    <title>${ title }</title>
+  `
+};

--- a/src/components/pageMetadata.js
+++ b/src/components/pageMetadata.js
@@ -15,7 +15,7 @@ function metaImage(ogImage) {
   `;
 }
 
-module.exports = async function(page, title, description, ogImage){
+module.exports = async function({ page, title, description, ogImage }){
   const project = await awaitProject;
   return `
     <meta charset="utf-8">

--- a/src/components/pageMetadata.js
+++ b/src/components/pageMetadata.js
@@ -23,7 +23,7 @@ module.exports = async function(page, title, description, ogImage){
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="${ project.display_name } Talk" />
-    <meta property='og:url' content="https://talk.sciencegossip.org${ page.url }" />
+    <meta property='og:url' content="https://talk.${ project.domain }${ page.url }" />
     <meta property='og:title' content="${ title }" />
 
     ${ description ? metaDesc(description) : ''}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,1 @@
-module.exports = {
-  project: {
-    name: 'illustratedlife',
-    prefix: 'SC'
-  }
-};
+module.exports = require('./sciencegossip');

--- a/src/config/penguinwatch.js
+++ b/src/config/penguinwatch.js
@@ -1,5 +1,6 @@
 module.exports = {
   project: {
+    domain: 'penguinwatch.org',
     name: 'penguin',
     prefix: 'PZ'
   }

--- a/src/config/sciencegossip.js
+++ b/src/config/sciencegossip.js
@@ -1,5 +1,6 @@
 module.exports = {
   project: {
+    domain: 'sciencegossip.org',
     name: 'illustratedlife',
     prefix: 'SC'
   }

--- a/src/helpers/project.js
+++ b/src/helpers/project.js
@@ -8,7 +8,9 @@ async function fetchProject(name) {
 }
 
 async function project() {
-  return await fetchProject(config.project.name);
+  const project = await fetchProject(config.project.name);
+  project.domain = config.project.domain;
+  return project;
 }
 
 module.exports = project();

--- a/src/site/_includes/layouts/default.njk
+++ b/src/site/_includes/layouts/default.njk
@@ -1,33 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="{{ project.display_name }} Talk" />
-    <meta property='og:url' content="https://talk.sciencegossip.org{{ page.url }}" />
-    <meta property='og:title' content="{{ title }}" />
-
-    {% if description %}
-    <meta name="description" content="{{ description }}" />
-    <meta name='twitter:description' content="{{ description }}" />
-    <meta property='og:description' content="{{ description }}" />
-    {% endif %}
-
-    {% if ogImage %}
-    <meta property='og:image' content="{{ ogImage }}" />
-    <meta name='twitter:image' content="{{ ogImage }}" />
-    {% endif %}
-
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@the_zooniverse" />
-    <meta name="twitter:site" content="@the_zooniverse" />
-
-    <link rel="icon" href="/img/favicon.ico">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,700">
+    {% pageMetadata page, title, description, ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
-    <title>{{ title }}</title>
   </head>
   <body>
     <header>

--- a/src/site/_includes/layouts/default.njk
+++ b/src/site/_includes/layouts/default.njk
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    {% pageMetadata page, title, description, ogImage %}
+    {% pageMetadata page=page, title=title, description=description, ogImage=ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
   </head>
   <body>

--- a/src/subjects/_includes/layouts/default.njk
+++ b/src/subjects/_includes/layouts/default.njk
@@ -1,33 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="{{ project.display_name }} Talk" />
-    <meta property='og:url' content="https://talk.sciencegossip.org{{ page.url }}" />
-    <meta property='og:title' content="{{ title }}" />
-
-    {% if description %}
-    <meta name="description" content="{{ description }}" />
-    <meta name='twitter:description' content="{{ description }}" />
-    <meta property='og:description' content="{{ description }}" />
-    {% endif %}
-
-    {% if ogImage %}
-    <meta property='og:image' content="{{ ogImage }}" />
-    <meta name='twitter:image' content="{{ ogImage }}" />
-    {% endif %}
-
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@the_zooniverse" />
-    <meta name="twitter:site" content="@the_zooniverse" />
-
-    <link rel="icon" href="/img/favicon.ico">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,700">
+    {% pageMetadata page, title, description, ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
-    <title>{{ title }}</title>
   </head>
   <body>
     <header>

--- a/src/subjects/_includes/layouts/default.njk
+++ b/src/subjects/_includes/layouts/default.njk
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    {% pageMetadata page, title, description, ogImage %}
+    {% pageMetadata page=page, title=title, description=description, ogImage=ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
   </head>
   <body>

--- a/src/tags/_includes/layouts/default.njk
+++ b/src/tags/_includes/layouts/default.njk
@@ -1,33 +1,8 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="{{ project.display_name }} Talk" />
-    <meta property='og:url' content="https://talk.sciencegossip.org{{ page.url }}" />
-    <meta property='og:title' content="{{ title }}" />
-
-    {% if description %}
-    <meta name="description" content="{{ description }}" />
-    <meta name='twitter:description' content="{{ description }}" />
-    <meta property='og:description' content="{{ description }}" />
-    {% endif %}
-
-    {% if ogImage %}
-    <meta property='og:image' content="{{ ogImage }}" />
-    <meta name='twitter:image' content="{{ ogImage }}" />
-    {% endif %}
-
-    <meta name="twitter:card" content="summary" />
-    <meta name="twitter:creator" content="@the_zooniverse" />
-    <meta name="twitter:site" content="@the_zooniverse" />
-
-    <link rel="icon" href="/img/favicon.ico">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,700">
+    {% pageMetadata page, title, description, ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
-    <title>{{ title }}</title>
   </head>
   <body>
     <header>

--- a/src/tags/_includes/layouts/default.njk
+++ b/src/tags/_includes/layouts/default.njk
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    {% pageMetadata page, title, description, ogImage %}
+    {% pageMetadata page=page, title=title, description=description, ogImage=ogImage %}
     <link rel="stylesheet" href="{% webpackAsset 'main.css' %}">
   </head>
   <body>


### PR DESCRIPTION
Add `project.domain` as a configuration option. Pass the domain to a `pageMetadata` tag, which renders page metadata for each of the default layouts.

Closes #36.