### PR TITLE
Add the Talk domain as a build arg.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn install
 Install the dependencies.
 
 ```
-yarn dev
+yarn dev talk.sciencegossip.org
 ```
 
 Use this script for local development.
@@ -20,13 +20,13 @@ Build and start a development site on http://localhost:8080.
 This will run all `dev:*` scripts from `package.json` in parallel to build the HTML & JSON resources. API responses are cached in `.cache/` for 30 days using [`eleventy-cache-assets`](https://github.com/11ty/eleventy-cache-assets).
 
 ```
-yarn dev:boards
+yarn dev:boards talk.sciencegossip.org
 ```
 
 Build development versions of `dist/boards`, `dist/api/boards` and `dist/api/discussions` then run a local Browsersync server. Useful if you want to test a build on `http://localhost:8080` without cleaning the `dist/` directory first.
 
 ```
-yarn build
+yarn build talk.sciencegossip.org
 ```
 Use this script to create resource pages prior to deploying. API responses are cached in `.cache/` for 30 days using [`eleventy-cache-assets`](https://github.com/11ty/eleventy-cache-assets).
 
@@ -43,7 +43,7 @@ Will run the following build scripts in order:
 Alternatively run those scripts individually to build the API data in `dist/api/` and HTML content in `dist/` and cache the API responses in `.cache`.
 
 ```
-yarn deploy
+yarn deploy -r talk.sciencegossip.org
 ```
 
 Copy the site from `/dist` to S3.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "url": "https://github.com/zooniverse/Talk-archiver"
   },
   "scripts": {
-    "build": "npm-run-all clean build:assets build:boards build:api build:site build:tags build:subjects:api build:subjects",
-    "build:assets": "NODE_ENV=production webpack --mode=production",
+    "build": "npm-run-all clean webpack:build:assets --parallel \"build:* {1}\" -- ",
     "build:api": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/api",
     "build:boards": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/boards",
     "build:subjects": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/subjects",
@@ -19,15 +18,15 @@
     "build:tags": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/tags",
     "clean": "rm -rf ./dist",
     "deploy": "s3-batch-upload -b zooniverse-static -r talk.sciencegossip.org -p ./dist -C 200 -acl 'public-read'",
-    "dev": "npm-run-all clean webpack:assets --parallel dev:*",
+    "dev": "npm-run-all clean webpack:dev:assets --parallel \"webpack:dev:assets --watch\" \"dev:* {1}\" -- ",
     "dev:api": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/api --watch",
     "dev:boards": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/boards --serve",
     "dev:subjects": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/subjects --watch",
     "dev:subjects:api": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/subjects:api --watch",
-    "dev:assets": "yarn run webpack:assets --watch",
     "dev:site": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --watch",
     "dev:tags": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/tags --watch",
-    "webpack:assets": "NODE_ENV=development webpack --mode=development"
+    "webpack:build:assets": "NODE_ENV=production webpack --mode=production",
+    "webpack:dev:assets": "NODE_ENV=development webpack --mode=development"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:site": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js",
     "build:tags": "NODE_ENV=production node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/tags",
     "clean": "rm -rf ./dist",
-    "deploy": "s3-batch-upload -b zooniverse-static -r talk.sciencegossip.org -p ./dist -C 200 -acl 'public-read'",
+    "deploy": "s3-batch-upload -b zooniverse-static -p ./dist -C 200 -acl 'public-read'",
     "dev": "npm-run-all clean webpack:dev:assets --parallel \"webpack:dev:assets --watch\" \"dev:* {1}\" -- ",
     "dev:api": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/api --watch",
     "dev:boards": "NODE_ENV=development node --max-old-space-size=${NODE_RAM:-12000} ./node_modules/@11ty/eleventy/cmd.js --input=src/boards --serve",

--- a/src/helpers/project.js
+++ b/src/helpers/project.js
@@ -1,15 +1,18 @@
 const awaitProjects = require('./projects');
-const config = require('../config');
 
-async function fetchProject(name) {
+const args = process.argv.slice(2);
+const talkDomain = args[args.length - 1];
+
+async function fetchProject() {
   const projects = await awaitProjects;
-  const [ project ] = projects.filter(project => project.name === name);
+  const domain = talkDomain.replace('talk.', '');
+  const [ project ] = projects.filter(project => project.bucket_path === `www.${domain}`);
   return project;
 }
 
 async function project() {
-  const project = await fetchProject(config.project.name);
-  project.domain = config.project.domain;
+  const project = await fetchProject();
+  project.domain = talkDomain;
   return project;
 }
 


### PR DESCRIPTION
Specify the target domain when building and deploying eg.
```
yarn build talk.sciencegossip.org
yarn build:boards --serve talk.sciencegossip.org
yarn dev talk.sciencegossip.org

yarn deploy -r talk.sciencegossip.org
```
The domain name must be the last argument in the build args list, and the S3 batch uploader uses the `-r` flag to specify the remote path.

Projects are looked up by comparing the domain against `project.bucket_path` in the projects data.