### PR TITLE
Redirect old hash fragments

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,7 @@
 // console.log("Elevenpack javascript is loaded");
 import slug from '../helpers/slug';
 
-function rewriteHashes() {
-  const { hash } = window.location;
-
+function rewriteHashes(hash) {
   const paths = hash.split('/');
   switch (paths[1]) {
     case "subjects":
@@ -31,9 +29,12 @@ function rewriteHashes() {
 }
 
 function onLoad() {
-  const redirectPath = rewriteHashes();
-  if (redirectPath.length) {
-    window.location.assign(`${window.location.origin}${redirectPath}`);
+  const { hash } = window.location;
+  if (hash.startsWith('#/')) {
+    const redirectPath = rewriteHashes(hash);
+    if (redirectPath.length) {
+      window.location.replace(`${window.location.origin}${redirectPath}`);
+    }
   }
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,1 +1,41 @@
 // console.log("Elevenpack javascript is loaded");
+import slug from '../helpers/slug';
+
+function rewriteHashes() {
+  const { hash } = window.location;
+
+  const paths = hash.split('/');
+  switch (paths[1]) {
+    case "subjects":
+    case "collections": {
+      return `/${paths[1]}/${paths[2]}/`;
+    }
+    case "users": {
+      return `/${paths[1]}/${slug(paths[2])}/`;
+    }
+  }
+  /*
+    tag fragments are of the form
+    #/search?tags[sometag]=true
+  */
+  if (paths[1].startsWith('search?tags')) {
+    const search = paths[1].split('?');
+    const params = search[1];
+    const tagMatch = /tags\[(\w+)\]=true/;
+    const matches = params.match(tagMatch);
+    const tag = matches[1];
+    return tag ? `/tags/${tag}/` : '';
+  }
+
+  return '';
+}
+
+function onLoad() {
+  const redirectPath = rewriteHashes();
+  if (redirectPath.length) {
+    window.location.assign(`${window.location.origin}${redirectPath}`);
+  }
+}
+
+window.addEventListener('load', onLoad);
+


### PR DESCRIPTION
Redirect old hash fragments for subjects, collections, users and tags to the new page URLs.

On window load, look for a fragment ID in the URL and redirect:

- `#/subjects/ASC0001fet` redirects to `/subjects/ASC0001fet/`.
- `#/collections/CSCL00000p` redirects to `/collections/CSCL00000p/`.
- `#/users/PinkPimpernel` redirects to `/users/pinkpimpernel/`.
- `#/search?tags[map]=true` redirects to `/tags/map/`.