### PR TITLE
Add roles to comments

### DIFF
--- a/src/components/discussionComment.js
+++ b/src/components/discussionComment.js
@@ -2,25 +2,30 @@ const avatar = require('./avatar');
 const awaitAvatars = require('../helpers/avatars');
 const moment = require('moment');
 const markdown = require('./markdown');
+const awaitRoles = require('../helpers/roles')
 const slug = require('../helpers/slug');
 
 function responseTo(comment) {
   return `<a href="#${comment._id }">in response to ${comment.user_name}'s comment.</a>`
 }
 
+function role(roles, userName) {
+  const [ role ] = roles.filter(role => role.name === userName);
+  return role ? `<span class="uppercase text-xs"> ${role.roles.join(', ')} </span>` : '';
+}
+
 module.exports = async function discussionComment({comment}) {
   const avatars = await awaitAvatars;
+  const roles = await awaitRoles;
   const created = moment(comment.created_at).format('LLL');
+
   return `
     <li id=${ comment._id } class="comment">
       <p>
-        <a href="/users/${slug(comment.user_name)}">
-          ${avatar(comment.user_name, avatars[comment.user_id])}
-        </a>
+        <a href="/users/${slug(comment.user_name)}">${avatar(comment.user_name, avatars[comment.user_id])}</a>
         by
-        <a href="/users/${slug(comment.user_name)}">
-          ${comment.user_name }
-        </a>
+        <a href="/users/${slug(comment.user_name)}">${comment.user_name}</a>
+        ${ role(roles, comment.user_name) }
         ${ comment.response_to ?  responseTo(comment.response_to) : ''}
       </p>
 

--- a/src/helpers/roles.js
+++ b/src/helpers/roles.js
@@ -1,0 +1,13 @@
+const API = require('./api');
+
+const zooTeam = ['DZM', 'bumishness', 'mrniaboc', 'VVH', 'srallen086'];
+
+async function fetchRoles() {
+  const roles = await API.get('users/roles');
+  zooTeam.forEach((name) => {
+    roles.push({ name, roles: ['Zooniverse Team'] });
+  })
+  return roles;
+};
+
+module.exports = fetchRoles();


### PR DESCRIPTION
Get roles from the Ouroboros API. Add in team roles, which were [embedded in the original code](https://github.com/zooniverse/Talk/blob/2e8ad17390c1d623f1868d078379e73958ff74e4/app/models/roles.coffee#L7-L8). Show roles next to a comment author's name, with minimal styling (uppercase and smallest text size.)

See https://quenchtalk.galaxyzoo.org/boards/BGS000000f/discussions/DGS000023k/ for examples of all the team roles in a single discussion.

Closes #51.