### PR TITLE
subjectLocation helper function

### DIFF
--- a/src/components/pageMetadata.js
+++ b/src/components/pageMetadata.js
@@ -1,4 +1,5 @@
 const awaitProject = require('../helpers/project');
+const subjectLocation = require("../helpers/subjectLocation");
 
 function metaDesc(description) {
   return `
@@ -10,8 +11,8 @@ function metaDesc(description) {
 
 function metaImage(ogImage) {
   return `
-    <meta property='og:image' content="${ ogImage }" />
-    <meta name='twitter:image' content="${ ogImage }" />
+    <meta property='og:image' content="${ subjectLocation(ogImage) }" />
+    <meta name='twitter:image' content="${ subjectLocation(ogImage) }" />
   `;
 }
 

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -1,13 +1,11 @@
+const subjectLocation = require('../helpers/subjectLocation')
+
 module.exports = function subjectImage(subject, size='standard', className) {
   try {
-    let url = subject.location.standard;
-    if ( Array.isArray(url) ) {
-      url = url[0];
-    }
-    url = url.replace('http://', 'https://');
+    let url = subjectLocation(subject.location.standard);
     const passThrough = (size === 'standard') || url.endsWith('.png');
     const zooniverseID = subject.zooniverse_id || subject._id;
-    const staticRoot = 'zooniverse-static.s3.amazonaws.com/';
+    const staticRoot = 'static.zooniverse.org';
     const thumbnailPath = url.replace('https://', '');
     const src =  passThrough ? url : `https://thumbnails.zooniverse.org/150x150/${thumbnailPath.replace(staticRoot, '')}`;
     const classAttr = className ? `class=${className}` : '';

--- a/src/helpers/subjectLocation.js
+++ b/src/helpers/subjectLocation.js
@@ -1,0 +1,9 @@
+module.exports = function subjectLocation(location) {
+  let url = location;
+  if ( Array.isArray(location) ) {
+    url = location[0];
+  }
+  url = url.replace('zooniverse-static.s3.amazonaws.com', 'static.zooniverse.org');
+  url = url.replace('http://', 'https://');
+  return url;
+}

--- a/src/site/userCollections/collection.11tydata.js
+++ b/src/site/userCollections/collection.11tydata.js
@@ -1,0 +1,12 @@
+function ogImage({ userCollection }) {
+  const subject = userCollection.subjects && userCollection.subjects[0];
+  return subject ? subject.location.standard : undefined
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => data.userCollection.title,
+    description: data => data.userCollection.description,
+    ogImage
+  }
+}

--- a/src/site/userCollections/collection.njk
+++ b/src/site/userCollections/collection.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: userCollection
 permalink: "/collections/{{ userCollection.zooniverse_id}}/"
-eleventyComputed:
-  title: "{{ userCollection.title }}"
-  description: "{{ userCollection.description }}"
-  ogImage: "{{ userCollection.subjects[0].location.standard }}"
 ---
 <main class="page-grid">
   <div>

--- a/src/site/users/comments.11tydata.js
+++ b/src/site/users/comments.11tydata.js
@@ -1,0 +1,12 @@
+function ogImage({ user }) {
+  const subject = user.subjects[0];
+  return subject ? subject.focus.location.standard : undefined
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => `Profile: ${data.user.name}: comments`,
+    description: data => `Subject comments by ${data.user.name} from ${data.project.display_name}.`,
+    ogImage
+  }
+}

--- a/src/site/users/comments.njk
+++ b/src/site/users/comments.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: user
 permalink: "/users/{{ user.name | slug }}/comments.html"
-eleventyComputed:
-  title: "Profile: {{ user.name }}: comments"
-  description: "Subject comments by {{ user.name }} on {{ project.display_name }}."
-  ogImage: "{{ user.subjects[0].focus.location.standard }}"
 ---
 <main>
   <h1><a href="/users/{{ user.name | slug }}">Profile: {{ user.name }}</a></h1>

--- a/src/site/users/user.njk
+++ b/src/site/users/user.njk
@@ -9,6 +9,7 @@ pagination:
 permalink: "/users/{{ user.name | slug }}/"
 eleventyComputed:
   title: "Profile: {{ user.name }}"
+  ogImage: "{{ user.avatar_url }}"
 ---
 <main class="page-grid">
   <h1>Profile: {{ user.name }}</h1>

--- a/src/subjectCollections/subjects/collections.11tydata.js
+++ b/src/subjectCollections/subjects/collections.11tydata.js
@@ -1,0 +1,7 @@
+module.exports = {
+  eleventyComputed: {
+    title: data => `Subject ${data.subject.zooniverse_id}: Collections`,
+    description: data => `Collections that include subject ${ data.subject.zooniverse_id } from ${ data.project.display_name }.`,
+    ogImage: data => data.subject.location.standard
+  }
+}

--- a/src/subjectCollections/subjects/collections.njk
+++ b/src/subjectCollections/subjects/collections.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: subject
 permalink: "/subjects/{{ subject.zooniverse_id }}/collections.html"
-eleventyComputed:
-  title: "Subject {{ subject.zooniverse_id }}: Collections"
-  description: "Collections that include subject {{ subject.zooniverse_id }} from {{ project.display_name }}."
-  ogImage: "{{ subject.location.standard }}"
 ---
 <div class="page-grid">
   <aside class=" focus">

--- a/src/subjects/subjects/subject.11tydata.js
+++ b/src/subjects/subjects/subject.11tydata.js
@@ -1,0 +1,7 @@
+module.exports = {
+  eleventyComputed: {
+    title: data => `Subject ${data.subject.zooniverse_id}`,
+    description: data => `Subject ${ data.subject.zooniverse_id } from ${ data.project.display_name }.`,
+    ogImage: data => data.subject.location.standard
+  }
+}

--- a/src/subjects/subjects/subject.njk
+++ b/src/subjects/subjects/subject.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: subject
 permalink: "/subjects/{{ subject.zooniverse_id }}/"
-eleventyComputed:
-  title: "Subject {{ subject.zooniverse_id }}"
-  description: "Subject {{ subject.zooniverse_id }} from {{ project.display_name }}."
-  ogImage: "{{ subject.location.standard }}"
 ---
 <div class="page-grid subject-page-grid">
   <main class="focus">

--- a/src/tags/userTags/collections.11tydata.js
+++ b/src/tags/userTags/collections.11tydata.js
@@ -1,0 +1,13 @@
+function ogImage({ subjects, tag }) {
+  const subjectID = tag.subjects[0];
+  const subject = subjects[subjectID];
+  return subject ? subject.location.standard : undefined;
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => `Tag: ${data.tag.name}: Collections`,
+    description: data => `Collections tagged with ${ data.tag.name } from ${ data.project.display_name }.`,
+    ogImage
+  }
+}

--- a/src/tags/userTags/collections.njk
+++ b/src/tags/userTags/collections.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: tag
 permalink: "/tags/{{ tag.name }}/collections.html"
-eleventyComputed:
-  title: "Tag: {{ tag.name }}"
-  description: "Collections tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>

--- a/src/tags/userTags/discussions.11tydata.js
+++ b/src/tags/userTags/discussions.11tydata.js
@@ -1,0 +1,13 @@
+function ogImage({ subjects, tag }) {
+  const subjectID = tag.subjects[0];
+  const subject = subjects[subjectID];
+  return subject ? subject.location.standard : undefined;
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => `Tag: ${data.tag.name}: Discussions`,
+    description: data => `Discussions tagged with ${ data.tag.name } from ${ data.project.display_name }.`,
+    ogImage
+  }
+}

--- a/src/tags/userTags/discussions.njk
+++ b/src/tags/userTags/discussions.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: tag
 permalink: "/tags/{{ tag.name }}/discussions.html"
-eleventyComputed:
-  title: "Tag: {{ tag.name }}"
-  description: "Discussions tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>

--- a/src/tags/userTags/subjects.11tydata.js
+++ b/src/tags/userTags/subjects.11tydata.js
@@ -1,0 +1,13 @@
+function ogImage({ subjects, tag }) {
+  const subjectID = tag.subjects[0];
+  const subject = subjects[subjectID];
+  return subject ? subject.location.standard : undefined;
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => `Tag: ${data.tag.name}: Subjects`,
+    description: data => `Subjects tagged with ${ data.tag.name } from ${ data.project.display_name }.`,
+    ogImage
+  }
+}

--- a/src/tags/userTags/subjects.njk
+++ b/src/tags/userTags/subjects.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: tag
 permalink: "/tags/{{ tag.name }}/subjects.html"
-eleventyComputed:
-  title: "Tag: {{ tag.name }}"
-  description: "Subjects tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main>
   <h1><a href="/tags/{{ tag.name }}">Tag: {{ tag.name }}</a></h1>

--- a/src/tags/userTags/tag.11tydata.js
+++ b/src/tags/userTags/tag.11tydata.js
@@ -1,0 +1,13 @@
+function ogImage({ subjects, tag }) {
+  const subjectID = tag.subjects[0];
+  const subject = subjects[subjectID];
+  return subject ? subject.location.standard : undefined;
+}
+
+module.exports = {
+  eleventyComputed: {
+    title: data => `Tag: ${data.tag.name}`,
+    description: data => `Content tagged with ${ data.tag.name } from ${ data.project.display_name }.`,
+    ogImage
+  }
+}

--- a/src/tags/userTags/tag.njk
+++ b/src/tags/userTags/tag.njk
@@ -7,10 +7,6 @@ pagination:
   size: 1
   alias: tag
 permalink: "/tags/{{ tag.name }}/"
-eleventyComputed:
-  title: "Tag: {{ tag.name }}"
-  description: "Content tagged with #{{ tag.name }} on {{ project.display_name }}."
-  ogImage: "{{ subjects[tag.subjects[0]].location.standard }}"
 ---
 <main class="page-grid">
   <h1>Tag: {{ tag.name }}</h1>


### PR DESCRIPTION
Add the subjectLocation helper function to `og:image` URLs and the `subjectImage` component:
- Use the first URL if location is an array.
- Replace the zooniverse-static S3 domain with static.zooniverse.org.
- Replace http:// with https://.

Closes #49.
Closes #50.