### PR TITLE
Handle talk domains correctly

### DIFF
--- a/src/helpers/project.js
+++ b/src/helpers/project.js
@@ -1,14 +1,15 @@
 const awaitProjects = require('./projects');
+const talkDomain = require('./talkDomain')
 
 const args = process.argv.slice(2);
-const talkDomain = args[args.length - 1];
+const buildName = args[args.length - 1];
 
 async function fetchProject() {
   const projects = await awaitProjects;
-  const domain = talkDomain.replace('talk.', 'www.');
-  let [ project ] = projects.filter(project => project.bucket_path === domain);
+  const bucketPath = buildName.replace('talk.', 'www.');
+  let [ project ] = projects.filter(project => project.bucket_path === bucketPath);
   if (!project) {
-    const namedProjects= projects.filter(project => project.name === domain);
+    const namedProjects= projects.filter(project => project.name === buildName);
     project = namedProjects[0];
   }
   return project;
@@ -16,7 +17,7 @@ async function fetchProject() {
 
 async function project() {
   const project = await fetchProject();
-  project.domain = talkDomain.replace('www.', 'talk.');
+  project.domain = talkDomain(project);
   return project;
 }
 

--- a/src/helpers/talkDomain.js
+++ b/src/helpers/talkDomain.js
@@ -1,0 +1,22 @@
+module.exports = function talkDomain({ bucket_path, name }) {
+  switch (name) {
+    case 'chimp': {
+      return 'talk.chimpandsee.org'
+    }
+    case 'galaxy_zoo': {
+      return 'talk.galaxyzoo.org'
+    }
+    case 'galaxy_zoo_starburst': {
+      return 'quenchtalk.galaxyzoo.org'
+    }
+    case 'higgs_hunter': {
+      return 'talk.higgshunters.org'
+    }
+    case 'radio': {
+      return 'radiotalk.galaxyzoo.org'
+    }
+    default: {
+      return bucket_path.replace('www.', 'talk.')
+    }
+  }
+}


### PR DESCRIPTION
Look up talk domains for Chimp & See, Higgs Hunters, Galaxy Zoo, Radio Galaxy Zoo or Galaxy Zoo Starburst. For all other projects, I think we can safely replace 'www.' with 'talk.', in the bucket path, in order to get the talk domain.

Closes #59.