### PR TITLE
Chimp & See preview images

### DIFF
--- a/src/components/pageMetadata.js
+++ b/src/components/pageMetadata.js
@@ -11,8 +11,8 @@ function metaDesc(description) {
 
 function metaImage(ogImage) {
   return `
-    <meta property='og:image' content="${ subjectLocation(ogImage.standard || ogImage) }" />
-    <meta name='twitter:image' content="${ subjectLocation(ogImage.standard || ogImage) }" />
+    <meta property='og:image' content="${ subjectLocation(ogImage.previews || ogImage.standard || ogImage) }" />
+    <meta name='twitter:image' content="${ subjectLocation(ogImage.previews || ogImage.standard || ogImage) }" />
   `;
 }
 

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -33,7 +33,7 @@ module.exports = function subjectImage(subject, size='standard', className) {
     const alt = `Subject ${zooniverseID}`;
     const { metadata } = subject;
     const counters = metadata && metadata.counters;
-    const poster = previewLocation[0] && previewLocation[0][0];
+    const poster = subjectLocation(previewLocation || subject.location);
     if (counters && counters.human) {
       src = 'https://placehold.it/300x215&text=Human'
     }

--- a/src/components/subjectImage.js
+++ b/src/components/subjectImage.js
@@ -4,9 +4,9 @@ function img(classAttr, alt, src) {
   return `<img ${classAttr} loading=lazy alt="${alt}" src=${src}>`
 }
 
-function video(classAttr, alt, src) {
+function video(classAttr, alt, src, poster) {
   return `
-    <video ${classAttr} src=${src}>
+    <video ${classAttr} controls poster=${poster} preload="none" src=${src}>
       <p>${alt}</p>
     </video>
   `
@@ -14,7 +14,12 @@ function video(classAttr, alt, src) {
 
 module.exports = function subjectImage(subject, size='standard', className) {
   try {
-    let url = subjectLocation(subject.location.standard || subject.location);
+/*
+  Chimp & See stores videos in location.standard and images in location.previews.
+*/
+    let previewLocation = subject.location.previews || subject.location.standard;
+    let standardLocation = size === 'standard' ? subject.location.standard : previewLocation;
+    let url = subjectLocation(standardLocation || subject.location);
     const passThrough = 
       (size === 'standard') ||
       url.endsWith('.png') ||
@@ -28,10 +33,11 @@ module.exports = function subjectImage(subject, size='standard', className) {
     const alt = `Subject ${zooniverseID}`;
     const { metadata } = subject;
     const counters = metadata && metadata.counters;
+    const poster = previewLocation[0] && previewLocation[0][0];
     if (counters && counters.human) {
       src = 'https://placehold.it/300x215&text=Human'
     }
-    return src.endsWith('.mp4') ? video(classAttr, alt, src) : img(classAttr, alt, src);
+    return src.endsWith('.mp4') ? video(classAttr, alt, src, poster) : img(classAttr, alt, src);
   } catch (e) {
     console.log(e.message);
     console.log(subject);

--- a/src/helpers/subjectLocation.js
+++ b/src/helpers/subjectLocation.js
@@ -6,6 +6,13 @@ function URLFromLocation(location) {
   }
 
   if ( Array.isArray(location) ) {
+  /*
+    Chimp & See uses arrays of arrays of image URLs.
+    Catch those before going to process arrays of strings.
+  */
+    if (Array.isArray(location[0])) {
+      return location[0][0] || PLACEHOLDER;
+    }
     return location[0] || PLACEHOLDER;
   }
 


### PR DESCRIPTION
Chimp & See stores preview images in subject.location.previews[0][0]. Use this location for thumbnails and openGraph images. Add `preload="none"` and a poster image to videos.

Closes #73.