### PR TITLE
Key users by user ID

### DIFF
--- a/src/helpers/collections.js
+++ b/src/helpers/collections.js
@@ -35,7 +35,7 @@ async function fetchCollections() {
     collection.tags = [];
     // console.log('Read collection', collection.zooniverse_id);
     userCollections[collection.zooniverse_id] = collection;
-    const owner = users[collection.user_name];
+    const owner = users[collection.user_id];
     if (owner) {
       owner.my_collections.push(collection);
     }

--- a/src/helpers/users.js
+++ b/src/helpers/users.js
@@ -39,14 +39,14 @@ async function fetchUsers() {
       user.name = user.name.split('@');
       user.name = user.name[0];
       user.subjects = [];
-      users[`${user.name}`] = user;
+      users[user.id] = user;
     }
   }
 
   const { subjects } = await discussionComments;
   for (subjectDiscussion of subjects ) {
     for (comment of subjectDiscussion.comments) {
-      const author = users[comment.user_name];
+      const author = users[comment.user_id];
       const focus = {
         location: subjectDiscussion.focus.location,
         zooniverse_id: subjectDiscussion.focus._id


### PR DESCRIPTION
Store users by user ID so that we can link up comments and collections to the correct user account, even if `user.name` changed over time.

This seems to work for all projects except Space Warps, where there are two user profiles that resolve to the same URL.
```
Output conflict: multiple input files are writing to `dist/api/users/pandamonium2956.json`. Use distinct `permalink` values to resolve this conflict.
```