### PR TITLE
use www.galaxyzoo.org for GZ subjects

### DIFF
--- a/src/helpers/subjectLocation.js
+++ b/src/helpers/subjectLocation.js
@@ -27,7 +27,7 @@ function URLFromLocation(location) {
 module.exports = function subjectLocation(location) {
   let url = URLFromLocation(location);
   url = url.replace('zooniverse-static.s3.amazonaws.com', 'static.zooniverse.org');
-  url = url.replace('www.galaxyzoo.org.s3.amazonaws.com', 's3.amazonaws.com/www.galaxyzoo.org');
+  url = url.replace('www.galaxyzoo.org.s3.amazonaws.com', 'www.galaxyzoo.org');
   url = url.replace('http://', 'https://');
   return url;
 }


### PR DESCRIPTION
Rewrite Galaxy Zoo S3 URLs to use www.galaxyzoo.org.

Here's an example.
Current URL: https://s3.amazonaws.com/www.galaxyzoo.org/subjects/standard/1237656563294994765.jpg
New URL: https://www.galaxyzoo.org/subjects/standard/1237656563294994765.jpg