### PR TITLE
Markdown: support sized images

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "limited-request-queue": "^5.1.0",
     "log-symbols": "^4.0.0",
     "markdown-it-emoji": "^1.4.0",
+    "markdown-it-imsize": "^2.0.1",
     "markdown-it-regex": "^0.2.0",
     "mini-css-extract-plugin": "^0.9.0",
     "moment": "^2.24.0",

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -1,6 +1,7 @@
 const awaitProject = require('../helpers/project');
 const markdownIt = require("markdown-it");
 const markdownItEmoji = require("markdown-it-emoji");
+const markdownItImsize = require("markdown-it-imsize");
 const markdownItRegex = require('markdown-it-regex').default;
 const options = {
   html: true,
@@ -65,6 +66,7 @@ async function zooMd() {
   const mentionCollections = await awaitMentionCollections;
   return markdownIt(options)
     .use(markdownItEmoji)
+    .use(markdownItImsize)
     .use(markdownItRegex, mentionUsers)
     .use(markdownItRegex, mentionTags)
     .use(markdownItRegex, mentionSubjects)
@@ -75,5 +77,7 @@ const awaitMd = zooMd();
 
 module.exports = async function markdown(content) {
   const md = await awaitMd;
+  const sizedImages = /\.(jpg|png|gif)=/gi;
+  content = content.replace(sizedImages, '.$1 =');
   return content ? md.render(content.trim()) : '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5736,6 +5736,11 @@ markdown-it-emoji@^1.4.0:
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
 
+markdown-it-imsize@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
+  integrity sha1-zKBCeQXQUziiR8ucqdloxc3dUXA=
+
 markdown-it-regex@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/markdown-it-regex/-/markdown-it-regex-0.2.0.tgz#e09ad2d75209720d591d3949e1142c75c0fbecf6"


### PR DESCRIPTION
Add `markdown-it-imsize` and replace missing whitespace in the URLs of sized images.

Fixes #87.